### PR TITLE
Prevent Unnecessary JSON Errors

### DIFF
--- a/opponents.py
+++ b/opponents.py
@@ -164,17 +164,17 @@ class Opponents:
         return opponent
 
     def _load(self, matchmaking_file: str) -> list[Opponent]:
-        try:
             if not os.path.isfile(matchmaking_file):
                 return []
             
             with open(matchmaking_file, encoding='utf-8') as file:
-                data = json.load(file)
+                try:
+                    data = json.load(file)
+                except json.JSONDecodeError as e:
+                    print (f"Error while processing the file '{matchmaking_file}': {e}.")
+                    return []
             
             return [Opponent.from_dict(item) for item in data]
-        except Exception as e:
-            print(f"Error while processing the file '{matchmaking_file}': {e}.")
-            return []
 
     def _save(self, matchmaking_file: str) -> None:
         try:

--- a/opponents.py
+++ b/opponents.py
@@ -164,10 +164,16 @@ class Opponents:
         return opponent
 
     def _load(self, matchmaking_file: str) -> list[Opponent]:
-        if os.path.isfile(matchmaking_file):
-            with open(matchmaking_file, encoding='utf-8') as json_input:
-                return [Opponent.from_dict(opponent) for opponent in json.load(json_input)]
-        else:
+        try:
+            if not os.path.isfile(matchmaking_file):
+                return []
+            
+            with open(matchmaking_file, encoding='utf-8') as file:
+                data = json.load(file)
+            
+            return [Opponent.from_dict(item) for item in data]
+        except Exception as e:
+            print(f"Error while processing the file '{matchmaking_file}': {e}.")
             return []
 
     def _save(self, matchmaking_file: str) -> None:

--- a/opponents.py
+++ b/opponents.py
@@ -164,17 +164,17 @@ class Opponents:
         return opponent
 
     def _load(self, matchmaking_file: str) -> list[Opponent]:
-            if not os.path.isfile(matchmaking_file):
+        if not os.path.isfile(matchmaking_file):
+            return []
+            
+        with open(matchmaking_file, encoding='utf-8') as file:
+            try:
+                data = json.load(file)
+            except json.JSONDecodeError as e:
+                print (f"Error while processing the file '{matchmaking_file}': {e}.")
                 return []
             
-            with open(matchmaking_file, encoding='utf-8') as file:
-                try:
-                    data = json.load(file)
-                except json.JSONDecodeError as e:
-                    print (f"Error while processing the file '{matchmaking_file}': {e}.")
-                    return []
-            
-            return [Opponent.from_dict(item) for item in data]
+        return [Opponent.from_dict(item) for item in data]
 
     def _save(self, matchmaking_file: str) -> None:
         try:

--- a/opponents.py
+++ b/opponents.py
@@ -171,7 +171,7 @@ class Opponents:
             try:
                 data = json.load(file)
             except json.JSONDecodeError as e:
-                print (f'Error while processing the file "{matchmaking_file}": {e}.')
+                print (f'Error while processing the file "{matchmaking_file}": {e}')
                 return []
 
         return [Opponent.from_dict(item) for item in data]

--- a/opponents.py
+++ b/opponents.py
@@ -171,7 +171,7 @@ class Opponents:
             try:
                 data = json.load(file)
             except json.JSONDecodeError as e:
-                print (f"Error while processing the file '{matchmaking_file}': {e}.")
+                print (f'Error while processing the file \'{matchmaking_file}\': {e}.')
                 return []
             
         return [Opponent.from_dict(item) for item in data]

--- a/opponents.py
+++ b/opponents.py
@@ -171,7 +171,7 @@ class Opponents:
             try:
                 data = json.load(file)
             except json.JSONDecodeError as e:
-                print (f'Error while processing the file \'{matchmaking_file}\': {e}.')
+                print (f'Error while processing the file "{matchmaking_file}": {e}.')
                 return []
             
         return [Opponent.from_dict(item) for item in data]

--- a/opponents.py
+++ b/opponents.py
@@ -166,14 +166,14 @@ class Opponents:
     def _load(self, matchmaking_file: str) -> list[Opponent]:
         if not os.path.isfile(matchmaking_file):
             return []
-            
+         
         with open(matchmaking_file, encoding='utf-8') as file:
             try:
                 data = json.load(file)
             except json.JSONDecodeError as e:
                 print (f'Error while processing the file "{matchmaking_file}": {e}.')
                 return []
-            
+
         return [Opponent.from_dict(item) for item in data]
 
     def _save(self, matchmaking_file: str) -> None:

--- a/opponents.py
+++ b/opponents.py
@@ -166,7 +166,7 @@ class Opponents:
     def _load(self, matchmaking_file: str) -> list[Opponent]:
         if not os.path.isfile(matchmaking_file):
             return []
-         
+
         with open(matchmaking_file, encoding='utf-8') as file:
             try:
                 data = json.load(file)


### PR DESCRIPTION
1. Wraps the _load method in a try-except block to prevent unnecessary JSON crashes such as An error occurred: Expecting value: line 1 column 1 (char 0).
2. Moves the return closer to the start of the function.