### PR TITLE
Adding the feature to ask for a player queue in opening explorer

### DIFF
--- a/config.py
+++ b/config.py
@@ -253,8 +253,6 @@ class Config:
         opening_explorer_sections = [
             ['enabled', bool, '"enabled" must be a bool.'],
             ['priority', int, '"priority" must be an integer.'],
-            ['use_player', bool, '"use_player" must be a bool.'],
-            ['player', int, '"player" must be an integer.'],
             ['only_without_book', bool, '"only_without_book" must be a bool.'],
             ['use_for_variants', bool, '"use_for_variants" must be a bool.'],
             ['min_time', int, '"min_time" must be an integer.'],

--- a/config.py
+++ b/config.py
@@ -270,12 +270,6 @@ class Config:
             if not isinstance(opening_explorer_section[subsection[0]], subsection[1]):
                 raise TypeError(f'`online_moves` `opening_explorer` field {subsection[2]}')
 
-        if opening_explorer_section['use_player']:  
-            if 'player' not in opening_explorer_section:  
-                raise RuntimeError('Your config does not have required '  
-                               '`online_moves` `opening_explorer` field `player` when `use_player` is true.')  
-            if not isinstance(opening_explorer_section['player'], str):  
-                raise TypeError('`online_moves` `opening_explorer` field "player" must be a string.')
           
         return Opening_Explorer_Config(opening_explorer_section['enabled'],
                                        opening_explorer_section['priority'],

--- a/config.py
+++ b/config.py
@@ -270,10 +270,9 @@ class Config:
             if not isinstance(opening_explorer_section[subsection[0]], subsection[1]):
                 raise TypeError(f'`online_moves` `opening_explorer` field {subsection[2]}')
 
-          
         return Opening_Explorer_Config(opening_explorer_section['enabled'],
                                        opening_explorer_section['priority'],
-                                       opening_explorer_section.get('player'), 
+                                       opening_explorer_section.get('player'),
                                        opening_explorer_section['only_without_book'],
                                        opening_explorer_section['use_for_variants'],
                                        opening_explorer_section['min_time'],

--- a/config.py
+++ b/config.py
@@ -273,7 +273,6 @@ class Config:
           
         return Opening_Explorer_Config(opening_explorer_section['enabled'],
                                        opening_explorer_section['priority'],
-                                       opening_explorer_section['use_player'],  
                                        opening_explorer_section.get('player'), 
                                        opening_explorer_section['only_without_book'],
                                        opening_explorer_section['use_for_variants'],

--- a/config.py
+++ b/config.py
@@ -253,6 +253,8 @@ class Config:
         opening_explorer_sections = [
             ['enabled', bool, '"enabled" must be a bool.'],
             ['priority', int, '"priority" must be an integer.'],
+            ['use_player', bool, '"use_player" must be a bool.'],
+            ['player', int, '"player" must be an integer.'],
             ['only_without_book', bool, '"only_without_book" must be a bool.'],
             ['use_for_variants', bool, '"use_for_variants" must be a bool.'],
             ['min_time', int, '"min_time" must be an integer.'],
@@ -270,8 +272,17 @@ class Config:
             if not isinstance(opening_explorer_section[subsection[0]], subsection[1]):
                 raise TypeError(f'`online_moves` `opening_explorer` field {subsection[2]}')
 
+        if opening_explorer_section['use_player']:  
+            if 'player' not in opening_explorer_section:  
+                raise RuntimeError('Your config does not have required '  
+                               '`online_moves` `opening_explorer` field `player` when `use_player` is true.')  
+            if not isinstance(opening_explorer_section['player'], str):  
+                raise TypeError('`online_moves` `opening_explorer` field "player" must be a string.')
+          
         return Opening_Explorer_Config(opening_explorer_section['enabled'],
                                        opening_explorer_section['priority'],
+                                       opening_explorer_section['use_player'],  
+                                       opening_explorer_section.get('player'), 
                                        opening_explorer_section['only_without_book'],
                                        opening_explorer_section['use_for_variants'],
                                        opening_explorer_section['min_time'],

--- a/config.yml.default
+++ b/config.yml.default
@@ -84,10 +84,8 @@ opening_books:
 online_moves:
   opening_explorer:
     enabled: false                        # Activate online moves from Lichess opening explorer. The move that has performed best for this bot is played.
-    priority: 300                         # Priority with which this move source is used. Higher priority is used first.     
-    use_player: false                     # Whether the Lichess opening explorer should be used with specific player.  
-    player: "Xxxxxx"                      # Specify which player to query  
-    only_without_book: false              # Whether the Lichess opening explorer should only be used if there is no matching book. 
+    priority: 300                         # Priority with which this move source is used. Higher priority is used first.    
+#   player: Username                      # Player whose Lichess opening explorer should be used. Comment this to use your own or with anti your opponent's.    only_without_book: false              # Whether the Lichess opening explorer should only be used if there is no matching book. 
     use_for_variants: false               # Whether the Lichess opening explorer should be used for other variants than standard and chess960.
     min_time: 10                          # Time the bot must have at least to use the online move. +10 seconds in games without increment.
     timeout: 5                            # Time the server has to respond.

--- a/config.yml.default
+++ b/config.yml.default
@@ -84,8 +84,10 @@ opening_books:
 online_moves:
   opening_explorer:
     enabled: false                        # Activate online moves from Lichess opening explorer. The move that has performed best for this bot is played.
-    priority: 300                         # Priority with which this move source is used. Higher priority is used first.
-    only_without_book: false              # Whether the Lichess opening explorer should only be used if there is no matching book.
+    priority: 300                         # Priority with which this move source is used. Higher priority is used first.     
+    use_player: true                      # Whether the Lichess opening explorer should be used with specific player.  
+    player: "Xxxxxx"                      # Specify which player to query  
+    only_without_book: false              # Whether the Lichess opening explorer should only be used if there is no matching book. 
     use_for_variants: false               # Whether the Lichess opening explorer should be used for other variants than standard and chess960.
     min_time: 10                          # Time the bot must have at least to use the online move. +10 seconds in games without increment.
     timeout: 5                            # Time the server has to respond.

--- a/config.yml.default
+++ b/config.yml.default
@@ -85,7 +85,7 @@ online_moves:
   opening_explorer:
     enabled: false                        # Activate online moves from Lichess opening explorer. The move that has performed best for this bot is played.
     priority: 300                         # Priority with which this move source is used. Higher priority is used first.     
-    use_player: true                      # Whether the Lichess opening explorer should be used with specific player.  
+    use_player: false                     # Whether the Lichess opening explorer should be used with specific player.  
     player: "Xxxxxx"                      # Specify which player to query  
     only_without_book: false              # Whether the Lichess opening explorer should only be used if there is no matching book. 
     use_for_variants: false               # Whether the Lichess opening explorer should be used for other variants than standard and chess960.

--- a/config.yml.default
+++ b/config.yml.default
@@ -84,8 +84,9 @@ opening_books:
 online_moves:
   opening_explorer:
     enabled: false                        # Activate online moves from Lichess opening explorer. The move that has performed best for this bot is played.
-    priority: 300                         # Priority with which this move source is used. Higher priority is used first.    
-#   player: Username                      # Player whose Lichess opening explorer should be used. Comment this to use your own or with anti your opponent's.    only_without_book: false              # Whether the Lichess opening explorer should only be used if there is no matching book. 
+    priority: 300                         # Priority with which this move source is used. Higher priority is used first.
+#   player: Username                      # Player whose Lichess opening explorer should be used. Comment this to use your own or with anti your opponent's.
+    only_without_book: false              # Whether the Lichess opening explorer should only be used if there is no matching book.
     use_for_variants: false               # Whether the Lichess opening explorer should be used for other variants than standard and chess960.
     min_time: 10                          # Time the bot must have at least to use the online move. +10 seconds in games without increment.
     timeout: 5                            # Time the server has to respond.

--- a/configs.py
+++ b/configs.py
@@ -53,6 +53,8 @@ class Opening_Books_Config:
 class Opening_Explorer_Config:
     enabled: bool
     priority: int
+    use_player: bool
+    player: str | None
     only_without_book: bool
     use_for_variants: bool
     min_time: int

--- a/configs.py
+++ b/configs.py
@@ -53,7 +53,6 @@ class Opening_Books_Config:
 class Opening_Explorer_Config:
     enabled: bool
     priority: int
-    use_player: bool
     player: str | None
     only_without_book: bool
     use_for_variants: bool

--- a/lichess_game.py
+++ b/lichess_game.py
@@ -364,9 +364,9 @@ class Lichess_Game:
         if out_of_book or too_deep or out_of_range or too_many_moves or not has_time:
             return
 
-        if self.config.online_moves.opening_explorer.player:  
+        if self.config.online_moves.opening_explorer.player:
             color = 'white' if self.board.turn else 'black'
-            username = self.config.online_moves.opening_explorer.player    
+            username = self.config.online_moves.opening_explorer.player
         elif self.config.online_moves.opening_explorer.anti:
             color = 'black' if self.board.turn else 'white'
             username = self.game_info.black_name if self.board.turn else self.game_info.white_name

--- a/lichess_game.py
+++ b/lichess_game.py
@@ -364,9 +364,9 @@ class Lichess_Game:
         if out_of_book or too_deep or out_of_range or too_many_moves or not has_time:
             return
 
-        if self.config.online_moves.opening_explorer.use_player:  
-            username = self.config.online_moves.opening_explorer.player  
-            color = 'white' if self.board.turn else 'black'  
+        if self.config.online_moves.opening_explorer.player:  
+            color = 'white' if self.board.turn else 'black'
+            username = self.config.online_moves.opening_explorer.player    
         elif self.config.online_moves.opening_explorer.anti:
             color = 'black' if self.board.turn else 'white'
             username = self.game_info.black_name if self.board.turn else self.game_info.white_name

--- a/lichess_game.py
+++ b/lichess_game.py
@@ -364,7 +364,10 @@ class Lichess_Game:
         if out_of_book or too_deep or out_of_range or too_many_moves or not has_time:
             return
 
-        if self.config.online_moves.opening_explorer.anti:
+        if self.config.online_moves.opening_explorer.use_player:  
+            username = self.config.online_moves.opening_explorer.player  
+            color = 'white' if self.board.turn else 'black'  
+        elif self.config.online_moves.opening_explorer.anti:
             color = 'black' if self.board.turn else 'white'
             username = self.game_info.black_name if self.board.turn else self.game_info.white_name
         else:


### PR DESCRIPTION
Changes:- The change allows user to ask for a specific player queue in opening explorer.
Advantage:- It has been found that lichess opening exploree some moves are some times not that good ,it can help to ignore by adding a strong bot name in ```player``` .
When no players name are there it works as normal.