### PR TITLE
Add min_rating option for draw offers and resignations

### DIFF
--- a/config.py
+++ b/config.py
@@ -3,7 +3,7 @@ import os.path
 import subprocess
 import sys
 from dataclasses import dataclass
-from typing import Any
+from typing import Any #/;
 
 import yaml
 

--- a/config.py
+++ b/config.py
@@ -382,56 +382,60 @@ class Config:
                                    Config._get_chessdb_config(online_moves_section['chessdb']),
                                    Config._get_online_egtb_config(online_moves_section['online_egtb']))
 
-@staticmethod  
-def _get_offer_draw_config(offer_draw_section: dict[str, Any]) -> Offer_Draw_Config:  
-    offer_draw_sections = [  
-        ['enabled', bool, '"enabled" must be a bool.'],  
-        ['score', int, '"score" must be an integer.'],  
-        ['consecutive_moves', int, '"consecutive_moves" must be an integer.'],  
-        ['min_game_length', int, '"min_game_length" must be an integer.'],  
-        ['against_humans', bool, '"against_humans" must be a bool.']]  
-  
-    for subsection in offer_draw_sections:  
-        if subsection[0] not in offer_draw_section:  
-            raise RuntimeError(f'Your config does not have required `offer_draw` subsection `{subsection[0]}`.')  
-  
-        if not isinstance(offer_draw_section[subsection[0]], subsection[1]):  
-            raise TypeError(f'`offer_draw` subsection {subsection[2]}')  
-  
-    # Validate optional min_rating field  
-    if 'min_rating' in offer_draw_section and not isinstance(offer_draw_section['min_rating'], int):  
+    @staticmethod
+    def _get_offer_draw_config(offer_draw_section: dict[str, Any]) -> Offer_Draw_Config:
+        offer_draw_sections = [
+            ['enabled', bool, '"enabled" must be a bool.'],
+            ['score', int, '"score" must be an integer.'],
+            ['consecutive_moves', int, '"consecutive_moves" must be an integer.'],
+            ['min_game_length', int, '"min_game_length" must be an integer.'],
+            ['against_humans', bool, '"against_humans" must be a bool.']]
+
+        for subsection in offer_draw_sections:
+            if subsection[0] not in offer_draw_section:
+                raise RuntimeError(f'Your config does not have required `offer_draw` subsection `{subsection[0]}`.')
+
+            if not isinstance(offer_draw_section[subsection[0]], subsection[1]):
+                raise TypeError(f'`offer_draw` subsection {subsection[2]}')
+
+        # Validate optional min_rating field  
+
+        if 'min_rating' in offer_draw_section and not isinstance(offer_draw_section['min_rating'], int):  
         raise TypeError('`offer_draw` subsection "min_rating" must be an integer.')  
   
-    return Offer_Draw_Config(offer_draw_section['enabled'],  
+        return Offer_Draw_Config(offer_draw_section['enabled'],  
                              offer_draw_section['score'],  
                              offer_draw_section['consecutive_moves'],  
                              offer_draw_section['min_game_length'],  
-                             offer_draw_section['against_humans'], 
+                             offer_draw_section['against_humans'],  
                              offer_draw_section.get('min_rating'))
+
     @staticmethod
-    def _get_resign_config(resign_section: dict[str, Any]) -> Resign_Config:  
-    resign_sections = [  
-        ['enabled', bool, '"enabled" must be a bool.'],  
-        ['score', int, '"score" must be an integer.'],  
-        ['consecutive_moves', int, '"consecutive_moves" must be an integer.'],  
-        ['against_humans', bool, '"against_humans" must be a bool.']]  
-  
-    for subsection in resign_sections:  
-        if subsection[0] not in resign_section:  
-            raise RuntimeError(f'Your config does not have required `resign` subsection `{subsection[0]}`.')  
-  
-        if not isinstance(resign_section[subsection[0]], subsection[1]):  
-            raise TypeError(f'`resign` subsection {subsection[2]}')  
-  
-    # Validate optional min_rating field  
-    if 'min_rating' in resign_section and not isinstance(resign_section['min_rating'], int):  
+    def _get_resign_config(resign_section: dict[str, Any]) -> Resign_Config:
+        resign_sections = [
+            ['enabled', bool, '"enabled" must be a bool.'],
+            ['score', int, '"score" must be an integer.'],
+            ['consecutive_moves', int, '"consecutive_moves" must be an integer.'],
+            ['against_humans', bool, '"against_humans" must be a bool.']]
+
+        for subsection in resign_sections:
+            if subsection[0] not in resign_section:
+                raise RuntimeError(f'Your config does not have required `resign` subsection `{subsection[0]}`.')
+
+            if not isinstance(resign_section[subsection[0]], subsection[1]):
+                raise TypeError(f'`resign` subsection {subsection[2]}')
+
+         #add optional min rating    
+
+        if 'min_rating' in resign_section and not isinstance(resign_section['min_rating'], int):  
         raise TypeError('`resign` subsection "min_rating" must be an integer.')  
   
-    return Resign_Config(resign_section['enabled'],  
+        return Resign_Config(resign_section['enabled'],  
                          resign_section['score'],  
                          resign_section['consecutive_moves'],  
                          resign_section['against_humans'],  
                          resign_section.get('min_rating'))
+
     @staticmethod
     def _get_challenge_config(challenge_section: dict[str, Any]) -> Challenge_Config:
         challenge_sections = [

--- a/config.py
+++ b/config.py
@@ -401,7 +401,7 @@ class Config:
         # Validate optional min_rating field  
 
         if 'min_rating' in offer_draw_section and not isinstance(offer_draw_section['min_rating'], int):  
-        raise TypeError('`offer_draw` subsection "min_rating" must be an integer.')  
+            raise TypeError('`offer_draw` subsection "min_rating" must be an integer.')  
   
         return Offer_Draw_Config(offer_draw_section['enabled'],  
                              offer_draw_section['score'],  
@@ -428,7 +428,7 @@ class Config:
          #add optional min rating    
 
         if 'min_rating' in resign_section and not isinstance(resign_section['min_rating'], int):  
-        raise TypeError('`resign` subsection "min_rating" must be an integer.')  
+            raise TypeError('`resign` subsection "min_rating" must be an integer.')  
   
         return Resign_Config(resign_section['enabled'],  
                          resign_section['score'],  

--- a/config.py
+++ b/config.py
@@ -3,7 +3,7 @@ import os.path
 import subprocess
 import sys
 from dataclasses import dataclass
-from typing import Any #/;
+from typing import Any
 
 import yaml
 

--- a/config.py
+++ b/config.py
@@ -272,6 +272,7 @@ class Config:
 
         return Opening_Explorer_Config(opening_explorer_section['enabled'],
                                        opening_explorer_section['priority'],
+                                       opening_explorer_section.get('player'),
                                        opening_explorer_section['only_without_book'],
                                        opening_explorer_section['use_for_variants'],
                                        opening_explorer_section['min_time'],

--- a/config.py
+++ b/config.py
@@ -382,48 +382,56 @@ class Config:
                                    Config._get_chessdb_config(online_moves_section['chessdb']),
                                    Config._get_online_egtb_config(online_moves_section['online_egtb']))
 
+@staticmethod  
+def _get_offer_draw_config(offer_draw_section: dict[str, Any]) -> Offer_Draw_Config:  
+    offer_draw_sections = [  
+        ['enabled', bool, '"enabled" must be a bool.'],  
+        ['score', int, '"score" must be an integer.'],  
+        ['consecutive_moves', int, '"consecutive_moves" must be an integer.'],  
+        ['min_game_length', int, '"min_game_length" must be an integer.'],  
+        ['against_humans', bool, '"against_humans" must be a bool.']]  
+  
+    for subsection in offer_draw_sections:  
+        if subsection[0] not in offer_draw_section:  
+            raise RuntimeError(f'Your config does not have required `offer_draw` subsection `{subsection[0]}`.')  
+  
+        if not isinstance(offer_draw_section[subsection[0]], subsection[1]):  
+            raise TypeError(f'`offer_draw` subsection {subsection[2]}')  
+  
+    # Validate optional min_rating field  
+    if 'min_rating' in offer_draw_section and not isinstance(offer_draw_section['min_rating'], int):  
+        raise TypeError('`offer_draw` subsection "min_rating" must be an integer.')  
+  
+    return Offer_Draw_Config(offer_draw_section['enabled'],  
+                             offer_draw_section['score'],  
+                             offer_draw_section['consecutive_moves'],  
+                             offer_draw_section['min_game_length'],  
+                             offer_draw_section['against_humans'], 
+                             offer_draw_section.get('min_rating'))
     @staticmethod
-    def _get_offer_draw_config(offer_draw_section: dict[str, Any]) -> Offer_Draw_Config:
-        offer_draw_sections = [
-            ['enabled', bool, '"enabled" must be a bool.'],
-            ['score', int, '"score" must be an integer.'],
-            ['consecutive_moves', int, '"consecutive_moves" must be an integer.'],
-            ['min_game_length', int, '"min_game_length" must be an integer.'],
-            ['against_humans', bool, '"against_humans" must be a bool.']]
-
-        for subsection in offer_draw_sections:
-            if subsection[0] not in offer_draw_section:
-                raise RuntimeError(f'Your config does not have required `offer_draw` subsection `{subsection[0]}`.')
-
-            if not isinstance(offer_draw_section[subsection[0]], subsection[1]):
-                raise TypeError(f'`offer_draw` subsection {subsection[2]}')
-
-        return Offer_Draw_Config(offer_draw_section['enabled'],
-                                 offer_draw_section['score'],
-                                 offer_draw_section['consecutive_moves'],
-                                 offer_draw_section['min_game_length'],
-                                 offer_draw_section['against_humans'])
-
-    @staticmethod
-    def _get_resign_config(resign_section: dict[str, Any]) -> Resign_Config:
-        resign_sections = [
-            ['enabled', bool, '"enabled" must be a bool.'],
-            ['score', int, '"score" must be an integer.'],
-            ['consecutive_moves', int, '"consecutive_moves" must be an integer.'],
-            ['against_humans', bool, '"against_humans" must be a bool.']]
-
-        for subsection in resign_sections:
-            if subsection[0] not in resign_section:
-                raise RuntimeError(f'Your config does not have required `resign` subsection `{subsection[0]}`.')
-
-            if not isinstance(resign_section[subsection[0]], subsection[1]):
-                raise TypeError(f'`resign` subsection {subsection[2]}')
-
-        return Resign_Config(resign_section['enabled'],
-                             resign_section['score'],
-                             resign_section['consecutive_moves'],
-                             resign_section['against_humans'])
-
+    def _get_resign_config(resign_section: dict[str, Any]) -> Resign_Config:  
+    resign_sections = [  
+        ['enabled', bool, '"enabled" must be a bool.'],  
+        ['score', int, '"score" must be an integer.'],  
+        ['consecutive_moves', int, '"consecutive_moves" must be an integer.'],  
+        ['against_humans', bool, '"against_humans" must be a bool.']]  
+  
+    for subsection in resign_sections:  
+        if subsection[0] not in resign_section:  
+            raise RuntimeError(f'Your config does not have required `resign` subsection `{subsection[0]}`.')  
+  
+        if not isinstance(resign_section[subsection[0]], subsection[1]):  
+            raise TypeError(f'`resign` subsection {subsection[2]}')  
+  
+    # Validate optional min_rating field  
+    if 'min_rating' in resign_section and not isinstance(resign_section['min_rating'], int):  
+        raise TypeError('`resign` subsection "min_rating" must be an integer.')  
+  
+    return Resign_Config(resign_section['enabled'],  
+                         resign_section['score'],  
+                         resign_section['consecutive_moves'],  
+                         resign_section['against_humans'],  
+                         resign_section.get('min_rating'))
     @staticmethod
     def _get_challenge_config(challenge_section: dict[str, Any]) -> Challenge_Config:
         challenge_sections = [

--- a/config.yml.default
+++ b/config.yml.default
@@ -126,12 +126,14 @@ offer_draw:
   consecutive_moves: 10                   # How many moves in a row the absolute value of the score has to be below the draw value
   min_game_length: 35                     # Earliest move in which draw is offered.
   against_humans: true                    # Activate whether these settings should apply against humans.
+#  min_rating: 2500                      # Minimum opponent rating to offer draws against. (Comment this line to disable)  
 
 resign:
   enabled: false                          # Activate whether the bot should resign games.
   score: -1000                            # If the score is less than or equal to this value, the bot resigns (in cp).
   consecutive_moves: 5                    # How many moves in a row the score has to be below the resign value.
-  against_humans: true                    # Activate whether these settings should apply against humans.
+  against_humans: true                    #Activate whether these settings should apply against humans.          
+ # min_rating: 2500                       # Minimum opponent rating to resign against. (Comment this line to disable
 
 challenge:                                # Incoming challenges.
   concurrency: 1                          # Number of games to play simultaneously.

--- a/config.yml.default
+++ b/config.yml.default
@@ -126,14 +126,14 @@ offer_draw:
   consecutive_moves: 10                   # How many moves in a row the absolute value of the score has to be below the draw value
   min_game_length: 35                     # Earliest move in which draw is offered.
   against_humans: true                    # Activate whether these settings should apply against humans.
-#  min_rating: 2500                      # Minimum opponent rating to offer draws against. (Comment this line to disable)  
+#  min_rating: 2300                       # Minimum opponent rating to offer draws against. (Comment this line to disable)  
 
 resign:
   enabled: false                          # Activate whether the bot should resign games.
   score: -1000                            # If the score is less than or equal to this value, the bot resigns (in cp).
   consecutive_moves: 5                    # How many moves in a row the score has to be below the resign value.
-  against_humans: true                    #Activate whether these settings should apply against humans.          
- # min_rating: 2500                       # Minimum opponent rating to resign against. (Comment this line to disable
+  against_humans: true                    # Activate whether these settings should apply against humans.          
+ # min_rating: 2300                       # Minimum opponent rating to resign against. (Comment this line to disable)
 
 challenge:                                # Incoming challenges.
   concurrency: 1                          # Number of games to play simultaneously.

--- a/config.yml.default
+++ b/config.yml.default
@@ -85,6 +85,7 @@ online_moves:
   opening_explorer:
     enabled: false                        # Activate online moves from Lichess opening explorer. The move that has performed best for this bot is played.
     priority: 300                         # Priority with which this move source is used. Higher priority is used first.
+ #   player: Username                     # Sets the explorer to a player , comment if not needed.
     only_without_book: false              # Whether the Lichess opening explorer should only be used if there is no matching book.
     use_for_variants: false               # Whether the Lichess opening explorer should be used for other variants than standard and chess960.
     min_time: 10                          # Time the bot must have at least to use the online move. +10 seconds in games without increment.

--- a/config.yml.default
+++ b/config.yml.default
@@ -1,4 +1,4 @@
-token: "XXXXXXXXXXXXXXXXXXXXXXXX"         # Lichess OAuth2 Token.
+token: "XXXXXXXXXXXXXXXXXXXXXXXX"         # Lichess OAuth2 Token
 
 engines:
   standard:                               # Engine used for standard chess and when no suitable special engine is configured.

--- a/configs.py
+++ b/configs.py
@@ -113,6 +113,7 @@ class Offer_Draw_Config:
     consecutive_moves: int
     min_game_length: int
     against_humans: bool
+    min_rating: int | None 
 
 
 @dataclass
@@ -121,6 +122,7 @@ class Resign_Config:
     score: int
     consecutive_moves: int
     against_humans: bool
+    min_rating: int | None 
 
 
 @dataclass

--- a/configs.py
+++ b/configs.py
@@ -53,6 +53,7 @@ class Opening_Books_Config:
 class Opening_Explorer_Config:
     enabled: bool
     priority: int
+    player: str | None
     only_without_book: bool
     use_for_variants: bool
     min_time: int

--- a/lichess_game.py
+++ b/lichess_game.py
@@ -364,7 +364,7 @@ class Lichess_Game:
 
         return check_book_key('standard')
 
-     async def _make_opening_explorer_move(self) -> Move_Response | None:
+    async def _make_opening_explorer_move(self) -> Move_Response | None:
         out_of_book = self.out_of_opening_explorer_counter >= 5
         too_deep = (False
                     if self.config.online_moves.opening_explorer.max_depth is None

--- a/lichess_game.py
+++ b/lichess_game.py
@@ -364,7 +364,7 @@ class Lichess_Game:
 
         return check_book_key('standard')
 
-    async def _make_opening_explorer_move(self) -> Move_Response | None:
+     async def _make_opening_explorer_move(self) -> Move_Response | None:
         out_of_book = self.out_of_opening_explorer_counter >= 5
         too_deep = (False
                     if self.config.online_moves.opening_explorer.max_depth is None
@@ -378,7 +378,10 @@ class Lichess_Game:
         if out_of_book or too_deep or out_of_range or too_many_moves or not has_time:
             return
 
-        if self.config.online_moves.opening_explorer.anti:
+        if self.config.online_moves.opening_explorer.player:
+            color = 'white' if self.board.turn else 'black'
+            username = self.config.online_moves.opening_explorer.player
+        elif self.config.online_moves.opening_explorer.anti:
             color = 'black' if self.board.turn else 'white'
             username = self.game_info.black_name if self.board.turn else self.game_info.white_name
         else:

--- a/lichess_game.py
+++ b/lichess_game.py
@@ -230,10 +230,12 @@ class Lichess_Game:
         if not self.engine.opponent.is_engine and not self.config.offer_draw.against_humans:
             return False
 
-        if (self.config.offer_draw.min_rating is not None and   
-        self.engine.opponent.rating is not None and   
-        self.engine.opponent.rating < self.config.offer_draw.min_rating):  
-        return False  
+        if (
+            self.config.offer_draw.min_rating is not None and   
+            self.engine.opponent.rating is not None and   
+            self.engine.opponent.rating < self.config.offer_draw.min_rating
+        ):  
+            return False  
 
         if not self.increment and self.opponent_time < 10.0:
             return False
@@ -260,10 +262,12 @@ class Lichess_Game:
         if not self.engine.opponent.is_engine and not self.config.resign.against_humans:
             return False
 
-        if (self.config.resign.min_rating is not None and   
-        self.engine.opponent.rating is not None and   
-        self.engine.opponent.rating < self.config.resign.min_rating):  
-        return False  
+        if (
+          self.config.resign.min_rating is not None and   
+          self.engine.opponent.rating is not None and   
+          self.engine.opponent.rating < self.config.resign.min_rating
+        ):  
+          return False  
         
         if not self.increment and self.opponent_time < 10.0:
             return False

--- a/lichess_game.py
+++ b/lichess_game.py
@@ -223,64 +223,63 @@ class Lichess_Game:
         if self.gaviota_tablebase:
             self.gaviota_tablebase.close()
 
-    def _offer_draw(self, move_response: Move_Response) -> bool:  
-    if not self.config.offer_draw.enabled:  
-        return False  
-  
-    if not self.engine.opponent.is_engine and not self.config.offer_draw.against_humans:  
-        return False  
-  
-    # Add min_rating check  
-    if (self.config.offer_draw.min_rating is not None and   
+    def _offer_draw(self, move_response: Move_Response) -> bool:
+        if not self.config.offer_draw.enabled:
+            return False
+
+        if not self.engine.opponent.is_engine and not self.config.offer_draw.against_humans:
+            return False
+
+        if (self.config.offer_draw.min_rating is not None and   
         self.engine.opponent.rating is not None and   
         self.engine.opponent.rating < self.config.offer_draw.min_rating):  
         return False  
-  
-    if not self.increment and self.opponent_time < 10.0:  
-        return False  
-  
-    if not move_response.is_engine_move:  
-        return move_response.is_drawish  
-  
-    if self.board.fullmove_number - (not self.is_white) < self.config.offer_draw.min_game_length:  
-        return False  
-  
-    if len(self.scores) < self.config.offer_draw.consecutive_moves:  
-        return False  
-  
-    for score in islice(self.scores, len(self.scores) - self.config.offer_draw.consecutive_moves, None):  
-        if abs(score.relative.score(mate_score=40_000)) > self.config.offer_draw.score:  
-            return False  
-  
-    return True
 
-    def _resign(self, move_response: Move_Response) -> bool:  
-    if not self.config.resign.enabled:  
-        return False  
-  
-    if not self.engine.opponent.is_engine and not self.config.resign.against_humans:  
-        return False  
-  
-    # Add min_rating check  
-    if (self.config.resign.min_rating is not None and   
+        if not self.increment and self.opponent_time < 10.0:
+            return False
+
+        if not move_response.is_engine_move:
+            return move_response.is_drawish
+
+        if self.board.fullmove_number - (not self.is_white) < self.config.offer_draw.min_game_length:
+            return False
+
+        if len(self.scores) < self.config.offer_draw.consecutive_moves:
+            return False
+
+        for score in islice(self.scores, len(self.scores) - self.config.offer_draw.consecutive_moves, None):
+            if abs(score.relative.score(mate_score=40_000)) > self.config.offer_draw.score:
+                return False
+
+        return True
+
+    def _resign(self, move_response: Move_Response) -> bool:
+        if not self.config.resign.enabled:
+            return False
+
+        if not self.engine.opponent.is_engine and not self.config.resign.against_humans:
+            return False
+
+        if (self.config.resign.min_rating is not None and   
         self.engine.opponent.rating is not None and   
         self.engine.opponent.rating < self.config.resign.min_rating):  
         return False  
-  
-    if not self.increment and self.opponent_time < 10.0:  
-        return False  
-  
-    if not move_response.is_engine_move:  
-        return move_response.is_resignable  
-  
-    if len(self.scores) < self.config.resign.consecutive_moves:  
-        return False  
-  
-    for score in islice(self.scores, len(self.scores) - self.config.resign.consecutive_moves, None):  
-        if score.relative.score(mate_score=40_000) > self.config.resign.score:  
-            return False  
-  
-    return True
+        
+        if not self.increment and self.opponent_time < 10.0:
+            return False
+
+        if not move_response.is_engine_move:
+            return move_response.is_resignable
+
+        if len(self.scores) < self.config.resign.consecutive_moves:
+            return False
+
+        for score in islice(self.scores, len(self.scores) - self.config.resign.consecutive_moves, None):
+            if score.relative.score(mate_score=40_000) > self.config.resign.score:
+                return False
+
+        return True
+
     async def _make_book_move(self) -> Move_Response | None:
         if self.book_settings.max_depth and self.board.ply() >= self.book_settings.max_depth:
             return

--- a/lichess_game.py
+++ b/lichess_game.py
@@ -263,11 +263,11 @@ class Lichess_Game:
             return False
 
         if (
-          self.config.resign.min_rating is not None and   
-          self.engine.opponent.rating is not None and   
-          self.engine.opponent.rating < self.config.resign.min_rating
+            self.config.resign.min_rating is not None and   
+            self.engine.opponent.rating is not None and   
+            self.engine.opponent.rating < self.config.resign.min_rating
         ):  
-          return False  
+            return False  
         
         if not self.increment and self.opponent_time < 10.0:
             return False


### PR DESCRIPTION
This update introduces a new option `min_rating` under the `offer_draw and resign sections in `config.yml`. 
It ensures the bot only offers a draw or resigns if the opponent’s rating is greater than or equal to the specified value.

### _**Key Changes**_

1.  It is optional 
2. Provides better rating control for users.