### PR TITLE
add !ping command

### DIFF
--- a/chatter.py
+++ b/chatter.py
@@ -1,7 +1,7 @@
 import os
 import platform
 from collections import defaultdict
-
+import asyncio
 import psutil
 
 from api import API
@@ -93,6 +93,8 @@ class Chatter:
                 await self.api.send_chat_message(self.game_info.id_, chat_message.room, self.lichess_game.engine.name)
             case 'name':
                 await self.api.send_chat_message(self.game_info.id_, chat_message.room, self.name_message)
+            case 'ping':
+                await self._handle_ping_command(chat_message)
             case 'printeval':
                 if not self.game_info.increment_ms and self.game_info.initial_time_ms < 180_000:
                     await self._send_last_message(chat_message.room)
@@ -122,11 +124,34 @@ class Chatter:
                 await self._send_takeback_message(chat_message.room, takeback_count, max_takebacks)
             case 'help' | 'commands':
                 if chat_message.room == 'player':
-                    message = 'Supported commands: !cpu, !draw, !eval, !motor, !name, !printeval, !ram, !takeback'
+                    message = 'Supported commands: !cpu, !draw, !eval, !motor, !name, !ping, !printeval, !ram, !takeback'
                 else:
-                    message = 'Supported commands: !cpu, !draw, !eval, !motor, !name, !printeval, !pv, !ram, !takeback'
+                    message = 'Supported commands: !cpu, !draw, !eval, !motor, !name, !ping, !printeval, !pv, !ram, !takeback'
 
                 await self.api.send_chat_message(self.game_info.id_, chat_message.room, message)
+            case _:
+                pass
+
+    async def _handle_ping_command(self, chat_message: Chat_Message) -> None:
+        ping_ms = await self._get_ping("lichess.org")
+        await self.api.send_chat_message(self.game_info.id_, chat_message.room, f"Ping: {ping_ms}")
+
+    async def _get_ping(self, host: str) -> str:
+        try:
+            count_flag = "-n" if platform.system().lower().startswith("win") else "-c"
+            proc = await asyncio.create_subprocess_exec(
+                "ping", count_flag, "1", host,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE
+            )
+            stdout, _ = await proc.communicate()
+            output = stdout.decode()
+            for line in output.splitlines():
+                if "time=" in line.lower():
+                    return line.split("time=")[1].split()[0]
+            return "unknown"
+        except Exception as e:
+            return f"error: {e}"
 
     async def _send_last_message(self, room: str) -> None:
         last_message = self.lichess_game.last_message.replace('Engine', 'Evaluation')


### PR DESCRIPTION
***PR Title***

Add !ping command to display latency to lichess.org

***Description***

This PR introduces a new chat command !ping in the Chatter class.

When a player or spectator types !ping in the chat, the bot will execute a system ping to lichess.org and respond with the measured latency in milliseconds.

The feature works cross-platform (Linux/Windows) using asyncio.create_subprocess_exec to call the native ping command.

Updated !help command outputs now include !ping for both players and spectators.

***Example***
```!ping
Bot: Ping: 32 ms
```
***Motivation***

This helps players and spectators quickly check network latency between the bot’s host server and lichess.org without leaving the game chat.