### PR TITLE
Add use_for_variants option for resign and draw sections

### DIFF
--- a/botli_dataclasses.py
+++ b/botli_dataclasses.py
@@ -24,7 +24,8 @@ class API_Challenge_Reponse:
 
 @dataclass
 class Book_Settings:
-    selection: Literal['weighted_random', 'uniform_random', 'best_move'] = 'best_move'
+    selection: Literal['weighted_random',
+                       'uniform_random', 'best_move'] = 'best_move'
     max_depth: int | None = None
     readers: dict[str, MemoryMappedReader] = field(default_factory=dict)
 
@@ -86,7 +87,9 @@ class Chat_Message:
     room: Literal['player', 'spectator']
 
     @classmethod
-    def from_chatLine_event(cls, chatLine_event: dict[str, Any]) -> 'Chat_Message':
+    def from_chatLine_event(cls,
+                            chatLine_event: dict[str,
+                                                 Any]) -> 'Chat_Message':
         username = chatLine_event['username']
         text = chatLine_event['text']
         room = chatLine_event['room']
@@ -118,7 +121,9 @@ class Game_Information:
     tournament_id: str | None
 
     @classmethod
-    def from_gameFull_event(cls, gameFull_event: dict[str, Any]) -> 'Game_Information':
+    def from_gameFull_event(cls,
+                            gameFull_event: dict[str,
+                                                 Any]) -> 'Game_Information':
         assert gameFull_event['type'] == 'gameFull'
 
         id_ = gameFull_event['id']
@@ -142,9 +147,27 @@ class Game_Information:
         state = gameFull_event['state']
         tournament_id = gameFull_event.get('tournamentId')
 
-        return cls(id_, white_title, white_name, white_rating, white_ai_level, white_provisional, black_title,
-                   black_name, black_rating, black_ai_level, black_provisional, initial_time_ms, increment_ms, speed,
-                   rated, variant, variant_name, initial_fen, state, tournament_id)
+        return cls(
+            id_,
+            white_title,
+            white_name,
+            white_rating,
+            white_ai_level,
+            white_provisional,
+            black_title,
+            black_name,
+            black_rating,
+            black_ai_level,
+            black_provisional,
+            initial_time_ms,
+            increment_ms,
+            speed,
+            rated,
+            variant,
+            variant_name,
+            initial_fen,
+            state,
+            tournament_id)
 
     @property
     def id_str(self) -> str:
@@ -158,7 +181,9 @@ class Game_Information:
     @property
     def white_str(self) -> str:
         provisional_str = '?' if self.white_provisional else ''
-        rating_str = f'{self.white_rating}{provisional_str}' if self.white_rating else f'Level {self.white_ai_level}'
+        rating_str = f'{
+            self.white_rating}{provisional_str}' if self.white_rating else f'Level {
+            self.white_ai_level}'
         return f'{self.white_name_str} ({rating_str})'
 
     @property
@@ -169,7 +194,9 @@ class Game_Information:
     @property
     def black_str(self) -> str:
         provisional_str = '?' if self.black_provisional else ''
-        rating_str = f'{self.black_rating}{provisional_str}' if self.black_rating else f'Level {self.black_ai_level}'
+        rating_str = f'{
+            self.black_rating}{provisional_str}' if self.black_rating else f'Level {
+            self.black_ai_level}'
         return f'{self.black_name_str} ({rating_str})'
 
     @property
@@ -205,11 +232,19 @@ class Game_Information:
 
     @property
     def white_opponent(self) -> chess.engine.Opponent:
-        return chess.engine.Opponent(self.white_name, self.white_title, self.white_rating, self.white_title == 'BOT')
+        return chess.engine.Opponent(
+            self.white_name,
+            self.white_title,
+            self.white_rating,
+            self.white_title == 'BOT')
 
     @property
     def black_opponent(self) -> chess.engine.Opponent:
-        return chess.engine.Opponent(self.black_name, self.black_title, self.black_rating, self.black_title == 'BOT')
+        return chess.engine.Opponent(
+            self.black_name,
+            self.black_title,
+            self.black_rating,
+            self.black_title == 'BOT')
 
 
 @dataclass
@@ -234,16 +269,19 @@ class Matchmaking_Data:
 
     @classmethod
     def from_dict(cls, dict_: dict[str, Any]) -> 'Matchmaking_Data':
-        release_time = datetime.fromisoformat(dict_['release_time']) if 'release_time' in dict_ else datetime.now()
+        release_time = datetime.fromisoformat(
+            dict_['release_time']) if 'release_time' in dict_ else datetime.now()
         multiplier = dict_.get('multiplier', 1)
-        color = Challenge_Color(dict_['color']) if 'color' in dict_ else Challenge_Color.WHITE
+        color = Challenge_Color(
+            dict_['color']) if 'color' in dict_ else Challenge_Color.WHITE
 
         return Matchmaking_Data(release_time, multiplier, color)
 
     def to_dict(self) -> dict[str, Any]:
         dict_ = {}
         if self.release_time > datetime.now():
-            dict_['release_time'] = self.release_time.isoformat(timespec='seconds')
+            dict_['release_time'] = self.release_time.isoformat(
+                timespec='seconds')
 
         if self.multiplier > 1:
             dict_['multiplier'] = self.multiplier
@@ -269,7 +307,8 @@ class Matchmaking_Type:
     max_rating_diff: int | None
 
     def __post_init__(self) -> None:
-        self.estimated_game_duration = timedelta(seconds=max(self.initial_time, 3) * 1.33 + self.increment * 94.48)
+        self.estimated_game_duration = timedelta(seconds=max(
+            self.initial_time, 3) * 1.33 + self.increment * 94.48)
 
     def __str__(self) -> str:
         initial_time_min = self.initial_time / 60
@@ -335,12 +374,21 @@ class Tournament:
     end_task: Task[None] | None = None
 
     @classmethod
-    def from_tournament_info(cls, tournament_info: dict[str, Any]) -> 'Tournament':
-        return cls(tournament_info['id'],
-                   start_time := datetime.fromisoformat(tournament_info['startsAt']),
-                   start_time + timedelta(minutes=tournament_info['minutes']),
-                   tournament_info.get('fullName', ''),
-                   tournament_info.get('botsAllowed', False))
+    def from_tournament_info(
+            cls, tournament_info: dict[str, Any]) -> 'Tournament':
+        return cls(
+            tournament_info['id'],
+            start_time := datetime.fromisoformat(
+                tournament_info['startsAt']),
+            start_time +
+            timedelta(
+                minutes=tournament_info['minutes']),
+            tournament_info.get(
+                'fullName',
+                ''),
+            tournament_info.get(
+                'botsAllowed',
+                False))
 
     @property
     def seconds_to_start(self) -> float:

--- a/challenge_validator.py
+++ b/challenge_validator.py
@@ -9,13 +9,16 @@ class Challenge_Validator:
     def __init__(self, config: Config, game_manager: Game_Manager) -> None:
         self.config = config
         self.game_manager = game_manager
-        self.time_controls = self._get_time_controls(self.config.challenge.time_controls)
+        self.time_controls = self._get_time_controls(
+            self.config.challenge.time_controls)
         self.min_increment = 0 if config.challenge.min_increment is None else config.challenge.min_increment
         self.max_increment = 180 if config.challenge.max_increment is None else config.challenge.max_increment
         self.min_initial = 0 if config.challenge.min_initial is None else config.challenge.min_initial
         self.max_initial = 315360000 if config.challenge.max_initial is None else config.challenge.max_initial
 
-    def get_decline_reason(self, challenge_event: dict[str, Any]) -> Decline_Reason | None:
+    def get_decline_reason(self,
+                           challenge_event: dict[str,
+                                                 Any]) -> Decline_Reason | None:
         speed: str = challenge_event['speed']
         if speed == 'ultraBullet':
             print('Time control "UltraBullet" is not allowed for bots.')
@@ -42,7 +45,8 @@ class Challenge_Validator:
             print('Challenger is blacklisted.')
             return Decline_Reason.GENERIC
 
-        if not (self.config.challenge.bot_modes or self.config.challenge.human_modes):
+        if not (
+                self.config.challenge.bot_modes or self.config.challenge.human_modes):
             print('Neither bots nor humans are allowed according to config.')
             return Decline_Reason.GENERIC
 
@@ -62,8 +66,10 @@ class Challenge_Validator:
             print('No time control is allowed according to config.')
             return Decline_Reason.GENERIC
 
-        if speed not in self.config.challenge.time_controls and (initial, increment) not in self.time_controls:
-            print(f'Time control "{speed}" is not allowed according to config.')
+        if speed not in self.config.challenge.time_controls and (
+                initial, increment) not in self.time_controls:
+            print(
+                f'Time control "{speed}" is not allowed according to config.')
             return Decline_Reason.TIME_CONTROL
 
         if increment < self.min_increment:
@@ -83,7 +89,8 @@ class Challenge_Validator:
             return Decline_Reason.TOO_SLOW
 
         if is_bot and speed == 'bullet' and increment == 0 and self.config.challenge.bullet_with_increment_only:
-            print('Bullet against bots is only allowed with increment according to config.')
+            print(
+                'Bullet against bots is only allowed with increment according to config.')
             return Decline_Reason.TOO_FAST
 
         is_rated: bool = challenge_event['rated']
@@ -101,6 +108,7 @@ class Challenge_Validator:
         for speed in speeds:
             if '+' in speed:
                 initial_str, increment_str = speed.split('+')
-                time_controls.append((int(float(initial_str) * 60), int(increment_str)))
+                time_controls.append(
+                    (int(float(initial_str) * 60), int(increment_str)))
 
         return time_controls

--- a/challenger.py
+++ b/challenger.py
@@ -8,25 +8,34 @@ class Challenger:
     def __init__(self, api: API) -> None:
         self.api = api
 
-    async def create(self, challenge_request: Challenge_Request) -> Challenge_Response:
+    async def create(
+            self,
+            challenge_request: Challenge_Request) -> Challenge_Response:
         challenge_id = None
 
         challenge_queue: asyncio.Queue[API_Challenge_Reponse] = asyncio.Queue()
-        asyncio.create_task(self.api.create_challenge(challenge_request, challenge_queue))
+        asyncio.create_task(
+            self.api.create_challenge(
+                challenge_request,
+                challenge_queue))
 
         while response := await challenge_queue.get():
             if response.challenge_id:
                 challenge_id = response.challenge_id
 
             if response.was_accepted:
-                return Challenge_Response(challenge_id=challenge_id, success=True)
+                return Challenge_Response(
+                    challenge_id=challenge_id, success=True)
 
             if response.was_declined:
                 return Challenge_Response(success=False)
 
             if response.has_reached_rate_limit:
-                print(f'Challenge against {challenge_request.opponent_username} failed due to Lichess rate limit.')
-                return Challenge_Response(success=False, has_reached_rate_limit=True)
+                print(
+                    f'Challenge against {
+                        challenge_request.opponent_username} failed due to Lichess rate limit.')
+                return Challenge_Response(
+                    success=False, has_reached_rate_limit=True)
 
             if response.invalid_initial:
                 print('Challenge failed due to invalid initial time.')
@@ -37,7 +46,9 @@ class Challenger:
                 return Challenge_Response(success=False, is_misconfigured=True)
 
             if response.has_timed_out:
-                print(f'Challenge against {challenge_request.opponent_username} has timed out.')
+                print(
+                    f'Challenge against {
+                        challenge_request.opponent_username} has timed out.')
                 if challenge_id is not None:
                     await self.api.cancel_challenge(challenge_id)
                 return Challenge_Response(success=False)

--- a/chatter.py
+++ b/chatter.py
@@ -29,11 +29,17 @@ class Chatter:
         self.ram_message = self._get_ram()
         self.player_greeting = self._format_message(config.messages.greeting)
         self.player_goodbye = self._format_message(config.messages.goodbye)
-        self.spectator_greeting = self._format_message(config.messages.greeting_spectators)
-        self.spectator_goodbye = self._format_message(config.messages.goodbye_spectators)
+        self.spectator_greeting = self._format_message(
+            config.messages.greeting_spectators)
+        self.spectator_goodbye = self._format_message(
+            config.messages.goodbye_spectators)
         self.print_eval_rooms: set[str] = set()
 
-    async def handle_chat_message(self, chatLine_Event: dict, takeback_count: int, max_takebacks: int) -> None:
+    async def handle_chat_message(
+            self,
+            chatLine_Event: dict,
+            takeback_count: int,
+            max_takebacks: int) -> None:
         chat_message = Chat_Message.from_chatLine_event(chatLine_Event)
 
         if chat_message.username == 'lichess':
@@ -81,7 +87,11 @@ class Chatter:
                                                                         'Feel free to challenge me again, '
                                                                         'I will accept the challenge if possible.'))
 
-    async def _handle_command(self, chat_message: Chat_Message, takeback_count: int, max_takebacks: int) -> None:
+    async def _handle_command(
+            self,
+            chat_message: Chat_Message,
+            takeback_count: int,
+            max_takebacks: int) -> None:
         match chat_message.text[1:].lower():
             case 'cpu':
                 await self.api.send_chat_message(self.game_info.id_, chat_message.room, self.cpu_message)
@@ -128,16 +138,19 @@ class Chatter:
                 await self._send_takeback_message(chat_message.room, takeback_count, max_takebacks)
             case 'help' | 'commands':
                 if chat_message.room == 'player':
-                    message = ('Supported commands: !cpu, !draw, !eval, !motor, '
-                               '!name, !ping, !printeval, !ram, !takeback')
+                    message = (
+                        'Supported commands: !cpu, !draw, !eval, !motor, '
+                        '!name, !ping, !printeval, !ram, !takeback')
                 else:
-                    message = ('Supported commands: !cpu, !draw, !eval, !motor, '
-                               '!name, !ping, !printeval, !pv, !ram, !takeback')
+                    message = (
+                        'Supported commands: !cpu, !draw, !eval, !motor, '
+                        '!name, !ping, !printeval, !pv, !ram, !takeback')
 
                 await self.api.send_chat_message(self.game_info.id_, chat_message.room, message)
 
     async def _send_last_message(self, room: str) -> None:
-        last_message = self.lichess_game.last_message.replace('Engine', 'Evaluation')
+        last_message = self.lichess_game.last_message.replace(
+            'Engine', 'Evaluation')
         last_message = ' '.join(last_message.split())
 
         if room == 'spectator':
@@ -145,7 +158,11 @@ class Chatter:
 
         await self.api.send_chat_message(self.game_info.id_, room, last_message)
 
-    async def _send_takeback_message(self, room: str, takeback_count: int, max_takebacks: int) -> None:
+    async def _send_takeback_message(
+            self,
+            room: str,
+            takeback_count: int,
+            max_takebacks: int) -> None:
         if not max_takebacks:
             message = f'{self.username} does not accept takebacks.'
         else:
@@ -197,15 +214,19 @@ class Chatter:
                 f'{config.offer_draw.consecutive_moves} moves.')
 
     def _get_name_message(self, version: str) -> str:
-        return (f'{self.username} running {self.lichess_game.engine.name} (BotLi {version})')
+        return (
+            f'{self.username} running {self.lichess_game.engine.name} (BotLi {version})')
 
     def _format_message(self, message: str | None) -> str | None:
         if not message:
             return
 
-        mapping = defaultdict(str, {'opponent': self.opponent_username, 'me': self.username,
-                                    'engine': self.lichess_game.engine.name, 'cpu': self.cpu_message,
-                                    'ram': self.ram_message})
+        mapping = defaultdict(str,
+                              {'opponent': self.opponent_username,
+                               'me': self.username,
+                               'engine': self.lichess_game.engine.name,
+                               'cpu': self.cpu_message,
+                               'ram': self.ram_message})
         return message.format_map(mapping)
 
     def _append_pv(self, initial_message: str = '') -> str:

--- a/config.py
+++ b/config.py
@@ -7,10 +7,24 @@ from typing import Any
 
 import yaml
 
-from configs import (Books_Config, Challenge_Config, ChessDB_Config, Engine_Config, Gaviota_Config,
-                     Lichess_Cloud_Config, Limit_Config, Matchmaking_Config, Matchmaking_Type_Config, Messages_Config,
-                     Offer_Draw_Config, Online_EGTB_Config, Online_Moves_Config, Opening_Books_Config,
-                     Opening_Explorer_Config, Resign_Config, Syzygy_Config)
+from configs import (
+    Books_Config,
+    Challenge_Config,
+    ChessDB_Config,
+    Engine_Config,
+    Gaviota_Config,
+    Lichess_Cloud_Config,
+    Limit_Config,
+    Matchmaking_Config,
+    Matchmaking_Type_Config,
+    Messages_Config,
+    Offer_Draw_Config,
+    Online_EGTB_Config,
+    Online_Moves_Config,
+    Opening_Books_Config,
+    Opening_Explorer_Config,
+    Resign_Config,
+    Syzygy_Config)
 
 
 @dataclass
@@ -37,7 +51,9 @@ class Config:
             try:
                 yaml_config = yaml.safe_load(yaml_input)
             except Exception as e:
-                print(f'There appears to be a syntax problem with your {yaml_path}', file=sys.stderr)
+                print(
+                    f'There appears to be a syntax problem with your {yaml_path}',
+                    file=sys.stderr)
                 raise e
 
         if not yaml_config.get('token') and 'LICHESS_BOT_TOKEN' in os.environ:
@@ -49,14 +65,20 @@ class Config:
         syzygy_config = cls._get_syzygy_configs(yaml_config['syzygy'])
         gaviota_config = cls._get_gaviota_config(yaml_config['gaviota'])
         opening_books_config = cls._get_opening_books_config(yaml_config)
-        online_moves_config = cls._get_online_moves_config(yaml_config['online_moves'])
-        offer_draw_config = cls._get_offer_draw_config(yaml_config['offer_draw'])
+        online_moves_config = cls._get_online_moves_config(
+            yaml_config['online_moves'])
+        offer_draw_config = cls._get_offer_draw_config(
+            yaml_config['offer_draw'])
         resign_config = cls._get_resign_config(yaml_config['resign'])
         challenge_config = cls._get_challenge_config(yaml_config['challenge'])
-        matchmaking_config = cls._get_matchmaking_config(yaml_config['matchmaking'])
-        messages_config = cls._get_messages_config(yaml_config['messages'] or {})
-        whitelist = [username.lower() for username in yaml_config.get('whitelist') or []]
-        blacklist = [username.lower() for username in yaml_config.get('blacklist') or []]
+        matchmaking_config = cls._get_matchmaking_config(
+            yaml_config['matchmaking'])
+        messages_config = cls._get_messages_config(
+            yaml_config['messages'] or {})
+        whitelist = [username.lower()
+                     for username in yaml_config.get('whitelist') or []]
+        blacklist = [username.lower()
+                     for username in yaml_config.get('blacklist') or []]
 
         return cls(yaml_config.get('url', 'https://lichess.org'),
                    yaml_config['token'],
@@ -96,13 +118,16 @@ class Config:
             ['books', dict, 'Section `books` must be a dictionary with indented keys followed by colons.']]
         for section in sections:
             if section[0] not in config:
-                raise RuntimeError(f'Your config does not have required section `{section[0]}`.')
+                raise RuntimeError(
+                    f'Your config does not have required section `{
+                        section[0]}`.')
 
             if not isinstance(config[section[0]], section[1]):
                 raise TypeError(section[2])
 
     @staticmethod
-    def _get_engine_configs(engines_section: dict[str, dict[str, Any]]) -> dict[str, Engine_Config]:
+    def _get_engine_configs(
+            engines_section: dict[str, dict[str, Any]]) -> dict[str, Engine_Config]:
         engines_sections = [
             ['dir', str, '"dir" must be a string wrapped in quotes.'],
             ['name', str, '"name" must be a string wrapped in quotes.'],
@@ -116,38 +141,51 @@ class Config:
         for key, settings in engines_section.items():
             for subsection in engines_sections:
                 if subsection[0] not in settings:
-                    raise RuntimeError(f'Your "{key}" engine does not have required field `{subsection[0]}`.')
+                    raise RuntimeError(
+                        f'Your "{key}" engine does not have required field `{
+                            subsection[0]}`.')
 
                 if not isinstance(settings[subsection[0]], subsection[1]):
-                    raise TypeError(f'`engines` `{key}` subsection {subsection[2]}')
+                    raise TypeError(
+                        f'`engines` `{key}` subsection {
+                            subsection[2]}')
 
             if not os.path.isdir(settings['dir']):
-                raise RuntimeError(f'Your engine dir "{settings["dir"]}" is not a directory.')
+                raise RuntimeError(
+                    f'Your engine dir "{
+                        settings["dir"]}" is not a directory.')
 
             settings['path'] = os.path.join(settings['dir'], settings['name'])
 
             if not os.path.isfile(settings['path']):
-                raise RuntimeError(f'The engine "{settings["path"]}" file does not exist.')
+                raise RuntimeError(
+                    f'The engine "{
+                        settings["path"]}" file does not exist.')
 
             if not os.access(settings['path'], os.X_OK):
-                raise RuntimeError(f'The engine "{settings["path"]}" doesnt have execute (x) permission. '
-                                   f'Try: chmod +x {settings["path"]}')
+                raise RuntimeError(
+                    f'The engine "{
+                        settings["path"]}" doesnt have execute (x) permission. ' f'Try: chmod +x {
+                        settings["path"]}')
 
             limits_settings = settings['limits'] or {}
 
-            engine_configs[key] = Engine_Config(settings['path'],
-                                                settings['ponder'],
-                                                settings['silence_stderr'],
-                                                settings['move_overhead_multiplier'],
-                                                settings['uci_options'] or {},
-                                                Limit_Config(limits_settings.get('time'),
-                                                             limits_settings.get('depth'),
-                                                             limits_settings.get('nodes')))
+            engine_configs[key] = Engine_Config(
+                settings['path'],
+                settings['ponder'],
+                settings['silence_stderr'],
+                settings['move_overhead_multiplier'],
+                settings['uci_options'] or {},
+                Limit_Config(
+                    limits_settings.get('time'),
+                    limits_settings.get('depth'),
+                    limits_settings.get('nodes')))
 
         return engine_configs
 
     @staticmethod
-    def _get_syzygy_configs(syzygy_section: dict[str, dict[str, Any]]) -> dict[str, Syzygy_Config]:
+    def _get_syzygy_configs(
+            syzygy_section: dict[str, dict[str, Any]]) -> dict[str, Syzygy_Config]:
         syzygy_sections = [
             ['enabled', bool, '"enabled" must be a bool.'],
             ['paths', list, '"paths" must be a list.'],
@@ -158,11 +196,14 @@ class Config:
         for key, settings in syzygy_section.items():
             for subsection in syzygy_sections:
                 if subsection[0] not in settings:
-                    raise RuntimeError('Your config does not have required '
-                                       f'`syzygy` `{key}` subsection `{subsection[0]}`.')
+                    raise RuntimeError(
+                        'Your config does not have required ' f'`syzygy` `{key}` subsection `{
+                            subsection[0]}`.')
 
                 if not isinstance(settings[subsection[0]], subsection[1]):
-                    raise TypeError(f'`syzygy` `{key}` subsection {subsection[2]}')
+                    raise TypeError(
+                        f'`syzygy` `{key}` subsection {
+                            subsection[2]}')
 
             if not settings['enabled']:
                 syzygy_configs[key] = Syzygy_Config(False, [], 0, False)
@@ -170,7 +211,8 @@ class Config:
 
             for path in settings['paths']:
                 if not os.path.isdir(path):
-                    raise RuntimeError(f'Your {key} syzygy path "{path}" is not a directory.')
+                    raise RuntimeError(
+                        f'Your {key} syzygy path "{path}" is not a directory.')
 
             syzygy_configs[key] = Syzygy_Config(settings['enabled'],
                                                 settings['paths'],
@@ -188,7 +230,9 @@ class Config:
 
         for subsection in gaviota_sections:
             if subsection[0] not in gaviota_section:
-                raise RuntimeError(f'Your config does not have required `gaviota` subsection `{subsection[0]}`.')
+                raise RuntimeError(
+                    f'Your config does not have required `gaviota` subsection `{
+                        subsection[0]}`.')
 
             if not isinstance(gaviota_section[subsection[0]], subsection[1]):
                 raise TypeError(f'`gaviota` subsection {subsection[2]}')
@@ -196,12 +240,17 @@ class Config:
         if gaviota_section['enabled']:
             for path in gaviota_section['paths']:
                 if not os.path.isdir(path):
-                    raise RuntimeError(f'Your gaviota directory "{path}" is not a directory.')
+                    raise RuntimeError(
+                        f'Your gaviota directory "{path}" is not a directory.')
 
-        return Gaviota_Config(gaviota_section['enabled'], gaviota_section['paths'], gaviota_section['max_pieces'])
+        return Gaviota_Config(
+            gaviota_section['enabled'],
+            gaviota_section['paths'],
+            gaviota_section['max_pieces'])
 
     @staticmethod
-    def _get_opening_books_config(config: dict[str, Any]) -> Opening_Books_Config:
+    def _get_opening_books_config(
+            config: dict[str, Any]) -> Opening_Books_Config:
         opening_books_sections = [
             ['enabled', bool, '"enabled" must be a bool.'],
             ['priority', int, '"priority" must be an integer.'],
@@ -209,9 +258,12 @@ class Config:
 
         for subsection in opening_books_sections:
             if subsection[0] not in config['opening_books']:
-                raise RuntimeError(f'Your config does not have required `opening_books` subsection `{subsection[0]}`.')
+                raise RuntimeError(
+                    f'Your config does not have required `opening_books` subsection `{
+                        subsection[0]}`.')
 
-            if not isinstance(config['opening_books'][subsection[0]], subsection[1]):
+            if not isinstance(config['opening_books']
+                              [subsection[0]], subsection[1]):
                 raise TypeError(f'`opening_books` subsection {subsection[2]}')
 
         if not config['opening_books']['enabled']:
@@ -225,23 +277,30 @@ class Config:
         for section, settings in config['opening_books']['books'].items():
             for subsection in opening_book_types_sections:
                 if subsection[0] not in settings:
-                    raise RuntimeError(f'Your `opening_books` `books` `{section}` section'
-                                       f'does not have required field `{subsection[0]}`.')
+                    raise RuntimeError(
+                        f'Your `opening_books` `books` `{section}` section' f'does not have required field `{
+                            subsection[0]}`.')
 
                 if not isinstance(settings[subsection[0]], subsection[1]):
-                    raise TypeError(f'`opening_books` `books` `{section}` field {subsection[2]}')
+                    raise TypeError(
+                        f'`opening_books` `books` `{section}` field {
+                            subsection[2]}')
 
             names: dict[str, str] = {}
             for book_name in settings['names']:
                 if book_name not in config['books']:
-                    raise RuntimeError(f'The book "{book_name}" is not defined in the books section.')
+                    raise RuntimeError(
+                        f'The book "{book_name}" is not defined in the books section.')
 
                 if not os.path.isfile(config['books'][book_name]):
-                    raise RuntimeError(f'The book "{book_name}" at "{config["books"][book_name]}" does not exist.')
+                    raise RuntimeError(
+                        f'The book "{book_name}" at "{
+                            config["books"][book_name]}" does not exist.')
 
                 names[book_name] = config['books'][book_name]
 
-            books[section] = Books_Config(settings['selection'], settings.get('max_depth'), names)
+            books[section] = Books_Config(
+                settings['selection'], settings.get('max_depth'), names)
 
         return Opening_Books_Config(config['opening_books']['enabled'],
                                     config['opening_books']['priority'],
@@ -249,7 +308,8 @@ class Config:
                                     books)
 
     @staticmethod
-    def _get_opening_explorer_config(opening_explorer_section: dict[str, Any]) -> Opening_Explorer_Config:
+    def _get_opening_explorer_config(
+            opening_explorer_section: dict[str, Any]) -> Opening_Explorer_Config:
         opening_explorer_sections = [
             ['enabled', bool, '"enabled" must be a bool.'],
             ['priority', int, '"priority" must be an integer.'],
@@ -264,28 +324,34 @@ class Config:
 
         for subsection in opening_explorer_sections:
             if subsection[0] not in opening_explorer_section:
-                raise RuntimeError('Your config does not have required '
-                                   f'`online_moves` `opening_explorer` field `{subsection[0]}`.')
+                raise RuntimeError(
+                    'Your config does not have required ' f'`online_moves` `opening_explorer` field `{
+                        subsection[0]}`.')
 
-            if not isinstance(opening_explorer_section[subsection[0]], subsection[1]):
-                raise TypeError(f'`online_moves` `opening_explorer` field {subsection[2]}')
+            if not isinstance(
+                    opening_explorer_section[subsection[0]], subsection[1]):
+                raise TypeError(
+                    f'`online_moves` `opening_explorer` field {
+                        subsection[2]}')
 
-        return Opening_Explorer_Config(opening_explorer_section['enabled'],
-                                       opening_explorer_section['priority'],
-                                       opening_explorer_section.get('player'),
-                                       opening_explorer_section['only_without_book'],
-                                       opening_explorer_section['use_for_variants'],
-                                       opening_explorer_section['min_time'],
-                                       opening_explorer_section['timeout'],
-                                       opening_explorer_section['min_games'],
-                                       opening_explorer_section['only_with_wins'],
-                                       opening_explorer_section['selection'],
-                                       opening_explorer_section['anti'],
-                                       opening_explorer_section.get('max_depth'),
-                                       opening_explorer_section.get('max_moves'))
+        return Opening_Explorer_Config(
+            opening_explorer_section['enabled'],
+            opening_explorer_section['priority'],
+            opening_explorer_section.get('player'),
+            opening_explorer_section['only_without_book'],
+            opening_explorer_section['use_for_variants'],
+            opening_explorer_section['min_time'],
+            opening_explorer_section['timeout'],
+            opening_explorer_section['min_games'],
+            opening_explorer_section['only_with_wins'],
+            opening_explorer_section['selection'],
+            opening_explorer_section['anti'],
+            opening_explorer_section.get('max_depth'),
+            opening_explorer_section.get('max_moves'))
 
     @staticmethod
-    def _get_lichess_cloud_config(lichess_cloud_section: dict[str, Any]) -> Lichess_Cloud_Config:
+    def _get_lichess_cloud_config(
+            lichess_cloud_section: dict[str, Any]) -> Lichess_Cloud_Config:
         lichess_cloud_sections = [
             ['enabled', bool, '"enabled" must be a bool.'],
             ['priority', int, '"priority" must be an integer.'],
@@ -297,11 +363,15 @@ class Config:
 
         for subsection in lichess_cloud_sections:
             if subsection[0] not in lichess_cloud_section:
-                raise RuntimeError('Your config does not have required '
-                                   f'`online_moves` `lichess_cloud` field `{subsection[0]}`.')
+                raise RuntimeError(
+                    'Your config does not have required ' f'`online_moves` `lichess_cloud` field `{
+                        subsection[0]}`.')
 
-            if not isinstance(lichess_cloud_section[subsection[0]], subsection[1]):
-                raise TypeError(f'`online_moves` `lichess_cloud` field {subsection[2]}')
+            if not isinstance(
+                    lichess_cloud_section[subsection[0]], subsection[1]):
+                raise TypeError(
+                    f'`online_moves` `lichess_cloud` field {
+                        subsection[2]}')
 
         return Lichess_Cloud_Config(lichess_cloud_section['enabled'],
                                     lichess_cloud_section['priority'],
@@ -326,11 +396,14 @@ class Config:
 
         for subsection in chessdb_sections:
             if subsection[0] not in chessdb_section:
-                raise RuntimeError('Your config does not have required '
-                                   f'`online_moves` `chessdb` field `{subsection[0]}`.')
+                raise RuntimeError(
+                    'Your config does not have required ' f'`online_moves` `chessdb` field `{
+                        subsection[0]}`.')
 
             if not isinstance(chessdb_section[subsection[0]], subsection[1]):
-                raise TypeError(f'`online_moves` `chessdb` field {subsection[2]}')
+                raise TypeError(
+                    f'`online_moves` `chessdb` field {
+                        subsection[2]}')
 
         return ChessDB_Config(chessdb_section['enabled'],
                               chessdb_section['priority'],
@@ -343,7 +416,8 @@ class Config:
                               chessdb_section.get('max_moves'))
 
     @staticmethod
-    def _get_online_egtb_config(online_egtb_section: dict[str, Any]) -> Online_EGTB_Config:
+    def _get_online_egtb_config(
+            online_egtb_section: dict[str, Any]) -> Online_EGTB_Config:
         online_egtb_sections = [
             ['enabled', bool, '"enabled" must be a bool.'],
             ['min_time', int, '"min_time" must be an integer.'],
@@ -351,18 +425,23 @@ class Config:
 
         for subsection in online_egtb_sections:
             if subsection[0] not in online_egtb_section:
-                raise RuntimeError('Your config does not have required '
-                                   f'`online_moves` `online_egtb` field `{subsection[0]}`.')
+                raise RuntimeError(
+                    'Your config does not have required ' f'`online_moves` `online_egtb` field `{
+                        subsection[0]}`.')
 
-            if not isinstance(online_egtb_section[subsection[0]], subsection[1]):
-                raise TypeError(f'`online_moves` `online_egtb` field {subsection[2]}')
+            if not isinstance(
+                    online_egtb_section[subsection[0]], subsection[1]):
+                raise TypeError(
+                    f'`online_moves` `online_egtb` field {
+                        subsection[2]}')
 
         return Online_EGTB_Config(online_egtb_section['enabled'],
                                   online_egtb_section['min_time'],
                                   online_egtb_section['timeout'])
 
     @staticmethod
-    def _get_online_moves_config(online_moves_section: dict[str, dict[str, Any]]) -> Online_Moves_Config:
+    def _get_online_moves_config(
+            online_moves_section: dict[str, dict[str, Any]]) -> Online_Moves_Config:
         online_moves_sections = [
             ['opening_explorer', dict, ('"opening_explorer" must be a dictionary '
                                         'with indented keys followed by colons.')],
@@ -372,19 +451,24 @@ class Config:
 
         for subsection in online_moves_sections:
             if subsection[0] not in online_moves_section:
-                raise RuntimeError('Your config does not have required '
-                                   f'`online_moves` subsection `{subsection[0]}`.')
+                raise RuntimeError(
+                    'Your config does not have required ' f'`online_moves` subsection `{
+                        subsection[0]}`.')
 
-            if not isinstance(online_moves_section[subsection[0]], subsection[1]):
+            if not isinstance(
+                    online_moves_section[subsection[0]], subsection[1]):
                 raise TypeError(f'`online_moves` subsection {subsection[2]}')
 
-        return Online_Moves_Config(Config._get_opening_explorer_config(online_moves_section['opening_explorer']),
-                                   Config._get_lichess_cloud_config(online_moves_section['lichess_cloud']),
-                                   Config._get_chessdb_config(online_moves_section['chessdb']),
-                                   Config._get_online_egtb_config(online_moves_section['online_egtb']))
+        return Online_Moves_Config(
+            Config._get_opening_explorer_config(
+                online_moves_section['opening_explorer']), Config._get_lichess_cloud_config(
+                online_moves_section['lichess_cloud']), Config._get_chessdb_config(
+                online_moves_section['chessdb']), Config._get_online_egtb_config(
+                    online_moves_section['online_egtb']))
 
     @staticmethod
-    def _get_offer_draw_config(offer_draw_section: dict[str, Any]) -> Offer_Draw_Config:
+    def _get_offer_draw_config(
+            offer_draw_section: dict[str, Any]) -> Offer_Draw_Config:
         offer_draw_sections = [
             ['enabled', bool, '"enabled" must be a bool.'],
             ['score', int, '"score" must be an integer.'],
@@ -394,9 +478,12 @@ class Config:
 
         for subsection in offer_draw_sections:
             if subsection[0] not in offer_draw_section:
-                raise RuntimeError(f'Your config does not have required `offer_draw` subsection `{subsection[0]}`.')
+                raise RuntimeError(
+                    f'Your config does not have required `offer_draw` subsection `{
+                        subsection[0]}`.')
 
-            if not isinstance(offer_draw_section[subsection[0]], subsection[1]):
+            if not isinstance(
+                    offer_draw_section[subsection[0]], subsection[1]):
                 raise TypeError(f'`offer_draw` subsection {subsection[2]}')
 
         return Offer_Draw_Config(offer_draw_section['enabled'],
@@ -416,7 +503,9 @@ class Config:
 
         for subsection in resign_sections:
             if subsection[0] not in resign_section:
-                raise RuntimeError(f'Your config does not have required `resign` subsection `{subsection[0]}`.')
+                raise RuntimeError(
+                    f'Your config does not have required `resign` subsection `{
+                        subsection[0]}`.')
 
             if not isinstance(resign_section[subsection[0]], subsection[1]):
                 raise TypeError(f'`resign` subsection {subsection[2]}')
@@ -428,7 +517,8 @@ class Config:
                              resign_section.get('min_rating'))
 
     @staticmethod
-    def _get_challenge_config(challenge_section: dict[str, Any]) -> Challenge_Config:
+    def _get_challenge_config(
+            challenge_section: dict[str, Any]) -> Challenge_Config:
         challenge_sections = [
             ['concurrency', int, '"concurrency" must be an integer.'],
             ['max_takebacks', int, '"max_takebacks" must be an integer.'],
@@ -440,25 +530,29 @@ class Config:
 
         for subsection in challenge_sections:
             if subsection[0] not in challenge_section:
-                raise RuntimeError(f'Your config does not have required `challenge` subsection `{subsection[0]}`.')
+                raise RuntimeError(
+                    f'Your config does not have required `challenge` subsection `{
+                        subsection[0]}`.')
 
             if not isinstance(challenge_section[subsection[0]], subsection[1]):
                 raise TypeError(f'`challenge` subsection {subsection[2]}')
 
-        return Challenge_Config(challenge_section['concurrency'],
-                                challenge_section['max_takebacks'],
-                                challenge_section['bullet_with_increment_only'],
-                                challenge_section.get('min_increment'),
-                                challenge_section.get('max_increment'),
-                                challenge_section.get('min_initial'),
-                                challenge_section.get('max_initial'),
-                                challenge_section['variants'],
-                                challenge_section['time_controls'] or [],
-                                challenge_section['bot_modes'] or [],
-                                challenge_section['human_modes'] or [])
+        return Challenge_Config(
+            challenge_section['concurrency'],
+            challenge_section['max_takebacks'],
+            challenge_section['bullet_with_increment_only'],
+            challenge_section.get('min_increment'),
+            challenge_section.get('max_increment'),
+            challenge_section.get('min_initial'),
+            challenge_section.get('max_initial'),
+            challenge_section['variants'],
+            challenge_section['time_controls'] or [],
+            challenge_section['bot_modes'] or [],
+            challenge_section['human_modes'] or [])
 
     @staticmethod
-    def _get_matchmaking_config(matchmaking_section: dict[str, Any]) -> Matchmaking_Config:
+    def _get_matchmaking_config(
+            matchmaking_section: dict[str, Any]) -> Matchmaking_Config:
         matchmaking_sections = [
             ['delay', int, '"delay" must be an integer.'],
             ['timeout', int, '"timeout" must be an integer.'],
@@ -467,31 +561,37 @@ class Config:
 
         for subsection in matchmaking_sections:
             if subsection[0] not in matchmaking_section:
-                raise RuntimeError(f'Your config does not have required `matchmaking` subsection `{subsection[0]}`.')
+                raise RuntimeError(
+                    f'Your config does not have required `matchmaking` subsection `{
+                        subsection[0]}`.')
 
-            if not isinstance(matchmaking_section[subsection[0]], subsection[1]):
+            if not isinstance(
+                    matchmaking_section[subsection[0]], subsection[1]):
                 raise TypeError(f'`matchmaking` subsection {subsection[2]}')
 
         types: dict[str, Matchmaking_Type_Config] = {}
-        for matchmaking_type, matchmaking_options in matchmaking_section['types'].items():
+        for matchmaking_type, matchmaking_options in matchmaking_section['types'].items(
+        ):
             if not isinstance(matchmaking_options, dict):
                 raise TypeError(f'`matchmaking` `types` subsection "{matchmaking_type}" must be a dictionary with '
                                 'indented keys followed by colons.')
 
             if 'tc' not in matchmaking_options:
-                raise RuntimeError(f'Your matchmaking type "{matchmaking_type}" does not have required `tc` field.')
+                raise RuntimeError(
+                    f'Your matchmaking type "{matchmaking_type}" does not have required `tc` field.')
 
             if not isinstance(matchmaking_options['tc'], str):
                 raise TypeError(f'`matchmaking` `types` `{matchmaking_type}` field `tc` must be a string in '
                                 'initial_minutes+increment_seconds format.')
 
-            types[matchmaking_type] = Matchmaking_Type_Config(matchmaking_options['tc'],
-                                                              matchmaking_options.get('rated'),
-                                                              matchmaking_options.get('variant'),
-                                                              matchmaking_options.get('weight'),
-                                                              matchmaking_options.get('multiplier'),
-                                                              matchmaking_options.get('min_rating_diff'),
-                                                              matchmaking_options.get('max_rating_diff'))
+            types[matchmaking_type] = Matchmaking_Type_Config(
+                matchmaking_options['tc'],
+                matchmaking_options.get('rated'),
+                matchmaking_options.get('variant'),
+                matchmaking_options.get('weight'),
+                matchmaking_options.get('multiplier'),
+                matchmaking_options.get('min_rating_diff'),
+                matchmaking_options.get('max_rating_diff'))
 
         return Matchmaking_Config(matchmaking_section['delay'],
                                   matchmaking_section['timeout'],
@@ -499,7 +599,8 @@ class Config:
                                   types)
 
     @staticmethod
-    def _get_messages_config(messages_section: dict[str, str]) -> Messages_Config:
+    def _get_messages_config(
+            messages_section: dict[str, str]) -> Messages_Config:
         messages_sections = [
             ['greeting', str, '"greeting" must be a string wrapped in quotes.'],
             ['goodbye', str, '"goodbye" must be a string wrapped in quotes.'],
@@ -508,11 +609,14 @@ class Config:
 
         for subsection in messages_sections:
             if subsection[0] in messages_section:
-                if not isinstance(messages_section[subsection[0]], subsection[1]):
+                if not isinstance(
+                        messages_section[subsection[0]], subsection[1]):
                     raise TypeError(f'`messages` subsection {subsection[2]}')
 
                 if messages_section[subsection[0]].strip() == '!printeval':
-                    print(f'Ignoring message "{subsection[0]}": "!printeval" is not allowed in messages.')
+                    print(
+                        f'Ignoring message "{
+                            subsection[0]}": "!printeval" is not allowed in messages.')
                     del messages_section[messages_section[subsection[0]]]
 
         return Messages_Config(messages_section.get('greeting'),
@@ -523,10 +627,16 @@ class Config:
     @staticmethod
     def _get_version() -> str:
         try:
-            output = subprocess.check_output(['git', 'show', '-s', '--date=format:%Y%m%d',
-                                              '--format=%cd', 'HEAD'], stderr=subprocess.DEVNULL)
+            output = subprocess.check_output(['git',
+                                              'show',
+                                              '-s',
+                                              '--date=format:%Y%m%d',
+                                              '--format=%cd',
+                                              'HEAD'],
+                                             stderr=subprocess.DEVNULL)
             commit_date = output.decode('utf-8').strip()
-            output = subprocess.check_output(['git', 'rev-parse', 'HEAD'], stderr=subprocess.DEVNULL)
+            output = subprocess.check_output(
+                ['git', 'rev-parse', 'HEAD'], stderr=subprocess.DEVNULL)
             commit_SHA = output.decode('utf-8').strip()[:7]
             return f'{commit_date}-{commit_SHA}'
         except (FileNotFoundError, subprocess.CalledProcessError):

--- a/configs.py
+++ b/configs.py
@@ -145,8 +145,15 @@ class Challenge_Config:
 class Matchmaking_Type_Config:
     tc: str
     rated: bool | None
-    variant: Literal['standard', 'chess960', 'crazyhouse', 'antichess', 'atomic',
-                     'horde', 'kingOfTheHill', 'racingKings', 'threeCheck'] | None
+    variant: Literal['standard',
+                     'chess960',
+                     'crazyhouse',
+                     'antichess',
+                     'atomic',
+                     'horde',
+                     'kingOfTheHill',
+                     'racingKings',
+                     'threeCheck'] | None
     weight: int | None
     multiplier: int | None
     min_rating_diff: int | None

--- a/engine.py
+++ b/engine.py
@@ -33,7 +33,12 @@ class Engine:
         await cls._configure_engine(engine, engine_config, syzygy_config)
         await engine.send_opponent_information(opponent=opponent)
 
-        return cls(transport, engine, engine_config.ponder, opponent, engine_config.limits)
+        return cls(
+            transport,
+            engine,
+            engine_config.ponder,
+            opponent,
+            engine_config.limits)
 
     @classmethod
     async def test(cls, engine_config: Engine_Config) -> None:
@@ -55,11 +60,13 @@ class Engine:
                                 syzygy_config: Syzygy_Config) -> None:
         for name, value in engine_config.uci_options.items():
             if name.lower() in chess.engine.MANAGED_OPTIONS:
-                print(f'UCI option "{name}" ignored as it is managed by the bot.')
+                print(
+                    f'UCI option "{name}" ignored as it is managed by the bot.')
             elif name in engine.options:
                 await engine.configure({name: value})
             else:
-                print(f'UCI option "{name}" ignored as it is not supported by the engine.')
+                print(
+                    f'UCI option "{name}" ignored as it is not supported by the engine.')
 
         if not syzygy_config.enabled:
             return
@@ -86,14 +93,20 @@ class Engine:
             if self.limit_config.time:
                 time_limit = min(time_limit, self.limit_config.time)
 
-            limit = chess.engine.Limit(time=time_limit, depth=self.limit_config.depth, nodes=self.limit_config.nodes)
+            limit = chess.engine.Limit(
+                time=time_limit,
+                depth=self.limit_config.depth,
+                nodes=self.limit_config.nodes)
             ponder = False
         else:
-            limit = chess.engine.Limit(white_clock=white_time, white_inc=increment,
-                                       black_clock=black_time, black_inc=increment,
-                                       time=self.limit_config.time,
-                                       depth=self.limit_config.depth,
-                                       nodes=self.limit_config.nodes)
+            limit = chess.engine.Limit(
+                white_clock=white_time,
+                white_inc=increment,
+                black_clock=black_time,
+                black_inc=increment,
+                time=self.limit_config.time,
+                depth=self.limit_config.depth,
+                nodes=self.limit_config.nodes)
             ponder = self.ponder
 
         result = await self.engine.play(board, limit, info=chess.engine.INFO_ALL, ponder=ponder)

--- a/event_handler.py
+++ b/event_handler.py
@@ -9,7 +9,12 @@ from game_manager import Game_Manager
 
 
 class Event_Handler:
-    def __init__(self, api: API, config: Config, username: str, game_manager: Game_Manager) -> None:
+    def __init__(
+            self,
+            api: API,
+            config: Config,
+            username: str,
+            game_manager: Game_Manager) -> None:
         self.api = api
         self.username = username
         self.game_manager = game_manager
@@ -28,13 +33,16 @@ class Event_Handler:
                     self.last_challenge_event = event['challenge']
                     self._print_challenge_event(event['challenge'])
 
-                    if decline_reason := self.challenge_validator.get_decline_reason(event['challenge']):
+                    if decline_reason := self.challenge_validator.get_decline_reason(
+                            event['challenge']):
                         print(128 * '‾')
                         await self.api.decline_challenge(event['challenge']['id'], decline_reason)
                         continue
 
-                    self.game_manager.add_challenge(Challenge(event['challenge']['id'],
-                                                              event['challenge']['challenger']['name']))
+                    self.game_manager.add_challenge(
+                        Challenge(
+                            event['challenge']['id'],
+                            event['challenge']['challenger']['name']))
                     print('Challenge added to queue.')
                     print(128 * '‾')
                 case 'gameStart':
@@ -47,13 +55,17 @@ class Event_Handler:
                     if opponent_name == self.username:
                         continue
 
-                    print(f'{opponent_name} declined challenge: {event["challenge"]["declineReason"]}')
+                    print(
+                        f'{opponent_name} declined challenge: {
+                            event["challenge"]["declineReason"]}')
                 case 'challengeCanceled':
                     if event['challenge']['challenger']['name'] == self.username:
                         continue
 
-                    self.game_manager.remove_challenge(Challenge(event['challenge']['id'],
-                                                                 event['challenge']['challenger']['name']))
+                    self.game_manager.remove_challenge(
+                        Challenge(
+                            event['challenge']['id'],
+                            event['challenge']['challenger']['name']))
                     self._print_challenge_event(event['challenge'])
                     print('Challenge has been canceled.')
                     print(128 * '‾')
@@ -65,13 +77,18 @@ class Event_Handler:
         title = challenge_event['challenger'].get('title') or ''
         name = challenge_event['challenger']['name']
         rating = challenge_event['challenger']['rating']
-        provisional = '?' if challenge_event['challenger'].get('provisional') else ''
-        challenger_str = f'Challenger: {title}{" " if title else ""}{name} ({rating}{provisional})'
-        tc_str = f'TC: {challenge_event["timeControl"].get("show", "Correspondence")}'
+        provisional = '?' if challenge_event['challenger'].get(
+            'provisional') else ''
+        challenger_str = f'Challenger: {title}{
+            " " if title else ""}{name} ({rating}{provisional})'
+        tc_str = f'TC: {
+            challenge_event["timeControl"].get(
+                "show", "Correspondence")}'
         rated_str = 'Rated' if challenge_event['rated'] else 'Casual'
         color_str = f'Color: {challenge_event["color"].capitalize()}'
         variant_str = f'Variant: {challenge_event["variant"]["name"]}'
         delimiter = 5 * ' '
 
         print(128 * '_')
-        print(delimiter.join([id_str, challenger_str, tc_str, rated_str, color_str, variant_str]))
+        print(delimiter.join([id_str, challenger_str,
+              tc_str, rated_str, color_str, variant_str]))

--- a/game.py
+++ b/game.py
@@ -9,7 +9,12 @@ from lichess_game import Lichess_Game
 
 
 class Game:
-    def __init__(self, api: API, config: Config, username: str, game_id: str) -> None:
+    def __init__(
+            self,
+            api: API,
+            config: Config,
+            username: str,
+            game_id: str) -> None:
         self.api = api
         self.config = config
         self.username = username
@@ -24,10 +29,18 @@ class Game:
 
     async def run(self) -> None:
         game_stream_queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
-        asyncio.create_task(self.api.get_game_stream(self.game_id, game_stream_queue))
+        asyncio.create_task(
+            self.api.get_game_stream(
+                self.game_id,
+                game_stream_queue))
         info = Game_Information.from_gameFull_event(await game_stream_queue.get())
         lichess_game = await Lichess_Game.acreate(self.api, self.config, self.username, info)
-        chatter = Chatter(self.api, self.config, self.username, info, lichess_game)
+        chatter = Chatter(
+            self.api,
+            self.config,
+            self.username,
+            info,
+            lichess_game)
 
         self._print_game_information(info)
 
@@ -48,7 +61,8 @@ class Game:
         max_takebacks = 0 if opponent_is_bot else self.config.challenge.max_takebacks
         if info.tournament_id is None:
             abortion_seconds = 30 if opponent_is_bot else 60
-            self.abortion_task = asyncio.create_task(self._abortion_task(lichess_game, chatter, abortion_seconds))
+            self.abortion_task = asyncio.create_task(
+                self._abortion_task(lichess_game, chatter, abortion_seconds))
 
         while event := await game_stream_queue.get():
             match event['type']:
@@ -86,13 +100,17 @@ class Game:
                 break
 
             if has_updated:
-                self.move_task = asyncio.create_task(self._make_move(lichess_game, chatter))
+                self.move_task = asyncio.create_task(
+                    self._make_move(lichess_game, chatter))
 
         if self.abortion_task:
             self.abortion_task.cancel()
         await lichess_game.close()
 
-    async def _make_move(self, lichess_game: Lichess_Game, chatter: Chatter) -> None:
+    async def _make_move(
+            self,
+            lichess_game: Lichess_Game,
+            chatter: Chatter) -> None:
         lichess_move = await lichess_game.make_move()
         if lichess_move.resign:
             await self.api.resign_game(self.game_id)
@@ -101,7 +119,11 @@ class Game:
             await chatter.print_eval()
         self.move_task = None
 
-    async def _abortion_task(self, lichess_game: Lichess_Game, chatter: Chatter, abortion_seconds: int) -> None:
+    async def _abortion_task(
+            self,
+            lichess_game: Lichess_Game,
+            chatter: Chatter,
+            abortion_seconds: int) -> None:
         await asyncio.sleep(abortion_seconds)
 
         if not lichess_game.is_our_turn and lichess_game.is_abortable:
@@ -179,7 +201,9 @@ class Game:
                     white_result = 'X'
                     black_result = 'X'
 
-        opponents_str = f'{info.white_str} {white_result} - {black_result} {info.black_str}'
+        opponents_str = f'{
+            info.white_str} {white_result} - {black_result} {
+            info.black_str}'
         message = (5 * ' ').join([info.id_str, opponents_str, message])
 
         print(f'{message}\n{128 * "‾"}')

--- a/game_manager.py
+++ b/game_manager.py
@@ -82,14 +82,17 @@ class Game_Manager:
 
     @property
     def is_busy(self) -> bool:
-        return len(self.tasks) + len(self.tournaments) + self.reserved_game_spots >= self.config.challenge.concurrency
+        return len(self.tasks) + len(self.tournaments) + \
+            self.reserved_game_spots >= self.config.challenge.concurrency
 
     def add_challenge(self, challenge: Challenge) -> None:
         if challenge not in self.open_challenges:
             self.open_challenges.append(challenge)
             self.changed_event.set()
 
-    def request_challenge(self, *challenge_requests: Challenge_Request) -> None:
+    def request_challenge(
+            self,
+            *challenge_requests: Challenge_Request) -> None:
         self.challenge_requests.extend(challenge_requests)
         self.changed_event.set()
 
@@ -99,7 +102,8 @@ class Game_Manager:
             self.changed_event.set()
 
     def on_game_started(self, game_event: dict[str, Any]) -> None:
-        if game_event['id'] in {started_game_event['id'] for started_game_event in self.started_game_events}:
+        if game_event['id'] in {started_game_event['id']
+                                for started_game_event in self.started_game_events}:
             return
 
         if game_event['id'] in {game.game_id for game in self.tasks.values()}:
@@ -122,22 +126,30 @@ class Game_Manager:
         self.changed_event.set()
         return True
 
-    def request_tournament_joining(self, tournament_id: str, team: str | None, password: str | None) -> None:
-        self.tournament_requests.append(Tournament_Request(tournament_id, team, password))
+    def request_tournament_joining(
+            self,
+            tournament_id: str,
+            team: str | None,
+            password: str | None) -> None:
+        self.tournament_requests.append(
+            Tournament_Request(
+                tournament_id, team, password))
         self.changed_event.set()
 
     def request_tournament_leaving(self, tournament_id: str) -> None:
         self.tournament_ids_to_leave.append(tournament_id)
         self.changed_event.set()
 
-    async def _process_tournament_request(self, tournament_request: Tournament_Request) -> None:
+    async def _process_tournament_request(
+            self, tournament_request: Tournament_Request) -> None:
         if tournament_request.id_ in self.unstarted_tournaments:
             return
 
         if tournament_request.id_ in self.tournaments:
             return
 
-        if tournament_request.id_ in {tournament.id_ for tournament in self.tournaments_to_join}:
+        if tournament_request.id_ in {
+                tournament.id_ for tournament in self.tournaments_to_join}:
             return
 
         tournament_info = await self.api.get_tournament_info(tournament_request.id_)
@@ -157,9 +169,12 @@ class Game_Manager:
             self.tournaments_to_join.append(tournament)
             return
 
-        tournament.start_task = asyncio.create_task(self._tournament_start_task(tournament))
+        tournament.start_task = asyncio.create_task(
+            self._tournament_start_task(tournament))
         self.unstarted_tournaments[tournament.id_] = tournament
-        print(f'Added tournament "{tournament.name}". Waiting for its start time to join.')
+        print(
+            f'Added tournament "{
+                tournament.name}". Waiting for its start time to join.')
 
     async def _join_tournament(self, tournament: Tournament) -> None:
         if tournament.seconds_to_finish <= 0.0:
@@ -167,7 +182,8 @@ class Game_Manager:
             return
 
         if await self.api.join_tournament(tournament.id_, tournament.team, tournament.password):
-            tournament.end_task = asyncio.create_task(self._tournament_end_task(tournament))
+            tournament.end_task = asyncio.create_task(
+                self._tournament_end_task(tournament))
             self.tournaments[tournament.id_] = tournament
             print(f'Joined tournament "{tournament.name}". Awaiting games ...')
 
@@ -223,7 +239,9 @@ class Game_Manager:
         if game.ejected_tournament in self.tournaments:
             self.tournaments[game.ejected_tournament].cancel()
             del self.tournaments[game.ejected_tournament]
-            print(f'Ignoring tournament "{game.ejected_tournament}" after failure to start the game.')
+            print(
+                f'Ignoring tournament "{
+                    game.ejected_tournament}" after failure to start the game.')
 
         self._set_next_matchmaking(self.config.matchmaking.delay)
         self.changed_event.set()
@@ -235,7 +253,8 @@ class Game_Manager:
         if 'tournamentId' in game_event and game_event['tournamentId'] not in self.tournaments:
             tournament_info = await self.api.get_tournament_info(game_event['tournamentId'])
             tournament = Tournament.from_tournament_info(tournament_info)
-            tournament.end_task = asyncio.create_task(self._tournament_end_task(tournament))
+            tournament.end_task = asyncio.create_task(
+                self._tournament_end_task(tournament))
             self.tournaments[tournament.id_] = tournament
             print(f'External joined tournament "{tournament.name}" detected.')
 
@@ -303,7 +322,8 @@ class Game_Manager:
             return
 
         if len(self.tasks) >= self.config.challenge.concurrency:
-            print('Max number of concurrent games exceeded. Ignoring already started game for now.')
+            print(
+                'Max number of concurrent games exceeded. Ignoring already started game for now.')
             return
 
         return self.started_game_events.popleft()
@@ -317,7 +337,8 @@ class Game_Manager:
 
         return self.tournaments_to_join.popleft()
 
-    async def _create_challenge(self, challenge_request: Challenge_Request) -> None:
+    async def _create_challenge(
+            self, challenge_request: Challenge_Request) -> None:
         print(f'Challenging {challenge_request.opponent_username} ...')
         response = await self.challenger.create(challenge_request)
 
@@ -327,6 +348,8 @@ class Game_Manager:
             print('Challenge queue cleared due to rate limiting.')
             self.challenge_requests.clear()
         elif challenge_request in self.challenge_requests:
-            print(f'Challenges against {challenge_request.opponent_username} removed from queue.')
+            print(
+                f'Challenges against {
+                    challenge_request.opponent_username} removed from queue.')
             while challenge_request in self.challenge_requests:
                 self.challenge_requests.remove(challenge_request)

--- a/opponents.py
+++ b/opponents.py
@@ -19,14 +19,16 @@ class Opponents:
 
     def get_opponent(self,
                      online_bots: list[Bot],
-                     matchmaking_type: Matchmaking_Type) -> tuple[Bot, Challenge_Color] | None:
+                     matchmaking_type: Matchmaking_Type) -> tuple[Bot,
+                                                                  Challenge_Color] | None:
         for bot in self._filter_bots(online_bots, matchmaking_type):
             if bot in self.busy_bots:
                 continue
 
             data = self.opponent_dict[bot.username][matchmaking_type.perf_type]
             if data.color == Challenge_Color.BLACK or data.release_time <= datetime.now():
-                self.last_opponent = (bot.username, data.color, matchmaking_type)
+                self.last_opponent = (
+                    bot.username, data.color, matchmaking_type)
                 return bot, data.color
 
         self.busy_bots.clear()
@@ -36,7 +38,8 @@ class Opponents:
         data = self.opponent_dict[username][matchmaking_type.perf_type]
 
         data.multiplier = 1 if success else data.multiplier * 2
-        timeout = (game_duration + self.delay) * matchmaking_type.multiplier * data.multiplier
+        timeout = (game_duration + self.delay) * \
+            matchmaking_type.multiplier * data.multiplier
 
         if data.release_time > datetime.now():
             data.release_time += timeout
@@ -44,7 +47,8 @@ class Opponents:
             data.release_time = datetime.now() + timeout
 
         release_str = data.release_time.isoformat(sep=' ', timespec='seconds')
-        print(f'{username} will not be challenged to a new game pair before {release_str}.')
+        print(
+            f'{username} will not be challenged to a new game pair before {release_str}.')
 
         if success and color == Challenge_Color.WHITE:
             data.color = Challenge_Color.BLACK
@@ -60,28 +64,37 @@ class Opponents:
 
         self.busy_bots.clear()
 
-    def _filter_bots(self, bots: list[Bot], matchmaking_type: Matchmaking_Type) -> list[Bot]:
+    def _filter_bots(
+            self,
+            bots: list[Bot],
+            matchmaking_type: Matchmaking_Type) -> list[Bot]:
         def bot_filter(bot: Bot) -> bool:
             if matchmaking_type.perf_type not in bot.rating_diffs:
                 return False
 
             if matchmaking_type.max_rating_diff:
-                if abs(bot.rating_diffs[matchmaking_type.perf_type]) > matchmaking_type.max_rating_diff:
+                if abs(bot.rating_diffs[matchmaking_type.perf_type]
+                       ) > matchmaking_type.max_rating_diff:
                     return False
 
             if matchmaking_type.min_rating_diff:
-                if abs(bot.rating_diffs[matchmaking_type.perf_type]) < matchmaking_type.min_rating_diff:
+                if abs(bot.rating_diffs[matchmaking_type.perf_type]
+                       ) < matchmaking_type.min_rating_diff:
                     return False
 
             return True
 
-        bots = sorted(filter(bot_filter, bots), key=lambda bot: abs(bot.rating_diffs[matchmaking_type.perf_type]))
+        bots = sorted(filter(bot_filter, bots), key=lambda bot: abs(
+            bot.rating_diffs[matchmaking_type.perf_type]))
         if not bots:
             raise NoOpponentException
 
         return bots
 
-    def _load(self, matchmaking_file: str) -> defaultdict[str, defaultdict[Perf_Type, Matchmaking_Data]]:
+    def _load(self,
+              matchmaking_file: str) -> defaultdict[str,
+                                                    defaultdict[Perf_Type,
+                                                                Matchmaking_Data]]:
         if not os.path.isfile(matchmaking_file):
             return defaultdict(lambda: defaultdict(Matchmaking_Data))
 
@@ -92,11 +105,13 @@ class Opponents:
                     return self._update_format(dict_)
 
             except json.JSONDecodeError as e:
-                print(f'Error while processing the file "{matchmaking_file}": {e}')
+                print(
+                    f'Error while processing the file "{matchmaking_file}": {e}')
                 return defaultdict(lambda: defaultdict(Matchmaking_Data))
 
             except PermissionError:
-                print('Loading the matchmaking file failed due to missing read permissions.')
+                print(
+                    'Loading the matchmaking file failed due to missing read permissions.')
                 return defaultdict(lambda: defaultdict(Matchmaking_Data))
 
             return defaultdict(lambda: defaultdict(Matchmaking_Data),
@@ -130,23 +145,27 @@ class Opponents:
             print('Saving the matchmaking file failed due to missing write permissions.')
 
     def _update_format(self,
-                       list_format: list[dict[str, Any]]
-                       ) -> defaultdict[str, defaultdict[Perf_Type, Matchmaking_Data]]:
-        dict_format: defaultdict[str,
-                                 defaultdict[Perf_Type,
-                                             Matchmaking_Data]] = defaultdict(lambda: defaultdict(Matchmaking_Data))
+                       list_format: list[dict[str,
+                                              Any]]) -> defaultdict[str,
+                                                                    defaultdict[Perf_Type,
+                                                                                Matchmaking_Data]]:
+        dict_format: defaultdict[str, defaultdict[Perf_Type, Matchmaking_Data]] = defaultdict(
+            lambda: defaultdict(Matchmaking_Data))
         for old_dict in list_format:
             username = old_dict.pop('username')
 
-            perf_types: defaultdict[Perf_Type, Matchmaking_Data] = defaultdict(Matchmaking_Data)
+            perf_types: defaultdict[Perf_Type, Matchmaking_Data] = defaultdict(
+                Matchmaking_Data)
             for perf_type, value in old_dict.items():
                 release_time = (datetime.fromisoformat(value['release_time'])
                                 if 'release_time' in value
                                 else datetime.now())
                 multiplier = value.get('multiplier', 1)
-                color = Challenge_Color(value['color']) if 'color' in value else Challenge_Color.WHITE
+                color = Challenge_Color(
+                    value['color']) if 'color' in value else Challenge_Color.WHITE
 
-                perf_types[Perf_Type(perf_type)] = Matchmaking_Data(release_time, multiplier, color)
+                perf_types[Perf_Type(perf_type)] = Matchmaking_Data(
+                    release_time, multiplier, color)
 
             dict_format[username] = perf_types
 

--- a/user_interface.py
+++ b/user_interface.py
@@ -35,14 +35,17 @@ COMMANDS = {
     'reset': 'Resets matchmaking. Usage: reset PERF_TYPE',
     'stop': 'Stops matchmaking mode.',
     'tournament': 'Joins tournament. Usage: tournament ID [TEAM_ID] [PASSWORD]',
-    'whitelist': 'Temporarily whitelists a user. Use config for permanent whitelisting. Usage: whitelist USERNAME'
-}
+    'whitelist': 'Temporarily whitelists a user. Use config for permanent whitelisting. Usage: whitelist USERNAME'}
 
 EnumT = TypeVar('EnumT', bound=StrEnum)
 
 
 class User_Interface:
-    async def main(self, commands: list[str], config_path: str, allow_upgrade: bool) -> None:
+    async def main(
+            self,
+            commands: list[str],
+            config_path: str,
+            allow_upgrade: bool) -> None:
         self.config = Config.from_yaml(config_path)
 
         async with API(self.config) as self.api:
@@ -55,10 +58,13 @@ class User_Interface:
             await self._test_engines()
 
             self.game_manager = Game_Manager(self.api, self.config, username)
-            self.game_manager_task = asyncio.create_task(self.game_manager.run())
+            self.game_manager_task = asyncio.create_task(
+                self.game_manager.run())
 
-            self.event_handler = Event_Handler(self.api, self.config, username, self.game_manager)
-            self.event_handler_task = asyncio.create_task(self.event_handler.run())
+            self.event_handler = Event_Handler(
+                self.api, self.config, username, self.game_manager)
+            self.event_handler_task = asyncio.create_task(
+                self.event_handler.run())
 
             signal.signal(signal.SIGTERM, self.signal_handler)
 
@@ -83,11 +89,15 @@ class User_Interface:
                 if len(command) > 0:
                     await self._handle_command(command)
 
-    async def _handle_bot_status(self, title: str | None, allow_upgrade: bool) -> None:
+    async def _handle_bot_status(
+            self,
+            title: str | None,
+            allow_upgrade: bool) -> None:
         if 'bot:play' not in await self.api.get_token_scopes(self.config.token):
-            print('Your token is missing the bot:play scope. This is mandatory to use BotLi.\n'
-                  'You can create such a token by following this link:\n'
-                  'https://lichess.org/account/oauth/token/create?scopes[]=bot:play&description=BotLi')
+            print(
+                'Your token is missing the bot:play scope. This is mandatory to use BotLi.\n'
+                'You can create such a token by following this link:\n'
+                'https://lichess.org/account/oauth/token/create?scopes[]=bot:play&description=BotLi')
             sys.exit(1)
 
         if title == 'BOT':
@@ -96,12 +106,14 @@ class User_Interface:
         print('\nBotLi can only be used by BOT accounts!\n')
 
         if not sys.stdin.isatty() and not allow_upgrade:
-            print('Start BotLi with the "--upgrade" flag if you are sure you want to upgrade this account.\n'
-                  'WARNING: This is irreversible. The account will only be able to play as a BOT.')
+            print(
+                'Start BotLi with the "--upgrade" flag if you are sure you want to upgrade this account.\n'
+                'WARNING: This is irreversible. The account will only be able to play as a BOT.')
             sys.exit(1)
         elif sys.stdin.isatty():
-            print('This will upgrade your account to a BOT account.\n'
-                  'WARNING: This is irreversible. The account will only be able to play as a BOT.')
+            print(
+                'This will upgrade your account to a BOT account.\n'
+                'WARNING: This is irreversible. The account will only be able to play as a BOT.')
             approval = input('Do you want to continue? [y/N]: ')
 
             if approval.lower() not in ['y', 'yes']:
@@ -171,16 +183,28 @@ class User_Interface:
             initial_time_str, increment_str = time_control.split('+')
             initial_time = int(float(initial_time_str) * 60)
             increment = int(increment_str)
-            color = Challenge_Color(command[3].lower()) if len(command) > 3 else Challenge_Color.RANDOM
-            rated = command[4].lower() in ['true', 'yes', 'rated'] if len(command) > 4 else True
-            variant = self._find_enum(command[5], Variant) if len(command) > 5 else Variant.STANDARD
+            color = Challenge_Color(command[3].lower()) if len(
+                command) > 3 else Challenge_Color.RANDOM
+            rated = command[4].lower() in [
+                'true', 'yes', 'rated'] if len(command) > 4 else True
+            variant = self._find_enum(command[5], Variant) if len(
+                command) > 5 else Variant.STANDARD
         except ValueError as e:
             print(e)
             return
 
-        challenge_request = Challenge_Request(opponent_username, initial_time, increment, rated, color, variant, 300)
+        challenge_request = Challenge_Request(
+            opponent_username,
+            initial_time,
+            increment,
+            rated,
+            color,
+            variant,
+            300)
         self.game_manager.request_challenge(challenge_request)
-        print(f'Challenge against {challenge_request.opponent_username} added to the queue.')
+        print(
+            f'Challenge against {
+                challenge_request.opponent_username} added to the queue.')
 
     def _clear(self) -> None:
         self.game_manager.challenge_requests.clear()
@@ -198,21 +222,38 @@ class User_Interface:
             initial_time_str, increment_str = time_control.split('+')
             initial_time = int(float(initial_time_str) * 60)
             increment = int(increment_str)
-            rated = command[4].lower() in ['true', 'yes', 'rated'] if len(command) > 4 else True
-            variant = self._find_enum(command[5], Variant) if len(command) > 5 else Variant.STANDARD
+            rated = command[4].lower() in [
+                'true', 'yes', 'rated'] if len(command) > 4 else True
+            variant = self._find_enum(command[5], Variant) if len(
+                command) > 5 else Variant.STANDARD
         except ValueError as e:
             print(e)
             return
 
         challenges: list[Challenge_Request] = []
         for _ in range(count):
-            challenges.append(Challenge_Request(opponent_username, initial_time,
-                              increment, rated, Challenge_Color.WHITE, variant, 300))
-            challenges.append(Challenge_Request(opponent_username, initial_time,
-                              increment, rated, Challenge_Color.BLACK, variant, 300))
+            challenges.append(
+                Challenge_Request(
+                    opponent_username,
+                    initial_time,
+                    increment,
+                    rated,
+                    Challenge_Color.WHITE,
+                    variant,
+                    300))
+            challenges.append(
+                Challenge_Request(
+                    opponent_username,
+                    initial_time,
+                    increment,
+                    rated,
+                    Challenge_Color.BLACK,
+                    variant,
+                    300))
 
         self.game_manager.request_challenge(*challenges)
-        print(f'Challenges for {count} game pairs against {opponent_username} added to the queue.')
+        print(
+            f'Challenges for {count} game pairs against {opponent_username} added to the queue.')
 
     async def _join(self, command: list[str]) -> None:
         if len(command) < 2 or len(command) > 3:
@@ -264,9 +305,18 @@ class User_Interface:
         else:
             color = Challenge_Color.RANDOM
 
-        challenge_request = Challenge_Request(opponent_username, initial_time, increment, rated, color, variant, 300)
+        challenge_request = Challenge_Request(
+            opponent_username,
+            initial_time,
+            increment,
+            rated,
+            color,
+            variant,
+            300)
         self.game_manager.request_challenge(challenge_request)
-        print(f'Challenge against {challenge_request.opponent_username} added to the queue.')
+        print(
+            f'Challenge against {
+                challenge_request.opponent_username} added to the queue.')
 
     def _reset(self, command: list[str]) -> None:
         if len(command) != 2:
@@ -297,7 +347,8 @@ class User_Interface:
         tournament_team = command[2] if len(command) > 2 else None
         tournament_password = command[3] if len(command) > 3 else None
 
-        self.game_manager.request_tournament_joining(tournament_id, tournament_team, tournament_password)
+        self.game_manager.request_tournament_joining(
+            tournament_id, tournament_team, tournament_password)
 
     def _whitelist(self, command: list[str]) -> None:
         if len(command) != 2:
@@ -331,7 +382,8 @@ class Autocompleter:
     def complete(self, text: str, state: int) -> str | None:
         if state == 0:
             if text:
-                self.matches = [s for s in self.options if s and s.startswith(text)]
+                self.matches = [
+                    s for s in self.options if s and s.startswith(text)]
             else:
                 self.matches = self.options[:]
 
@@ -343,13 +395,33 @@ class Autocompleter:
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('commands', nargs='*', help='Commands that BotLi executes.')
-    parser.add_argument('--config', '-c', default='config.yml', help='Path to config.yml.')
-    parser.add_argument('--upgrade', '-u', action='store_true', help='Upgrade account to BOT account.')
-    parser.add_argument('--debug', '-d', action='store_true', help='Enable debug logging.')
+    parser.add_argument(
+        'commands',
+        nargs='*',
+        help='Commands that BotLi executes.')
+    parser.add_argument(
+        '--config',
+        '-c',
+        default='config.yml',
+        help='Path to config.yml.')
+    parser.add_argument(
+        '--upgrade',
+        '-u',
+        action='store_true',
+        help='Upgrade account to BOT account.')
+    parser.add_argument(
+        '--debug',
+        '-d',
+        action='store_true',
+        help='Enable debug logging.')
     args = parser.parse_args()
 
     if args.debug:
         logging.basicConfig(level=logging.DEBUG)
 
-    asyncio.run(User_Interface().main(args.commands, args.config, args.upgrade), debug=args.debug)
+    asyncio.run(
+        User_Interface().main(
+            args.commands,
+            args.config,
+            args.upgrade),
+        debug=args.debug)


### PR DESCRIPTION
This PR adds a new use_for_variants boolean configuration field to both the offer_draw and resign sections, allowing users to control whether these features should apply to chess variants or only standard chess games.  I wanted to make it compulsory for the easier decision , keeping no defaults as fairy stockfish often gives wrong eval for some variants such as once i saw both side fsf gave +14.90 advantage . 