### PR TITLE
Add !ping command

### DIFF
--- a/api.py
+++ b/api.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import logging
+import time
 from typing import Any
 
 import aiohttp
@@ -293,6 +294,14 @@ class API:
                 print(f'Joining tournament "{tournament_id}" failed: {json_response["error"]}')
                 return False
             return True
+
+    async def ping(self) -> float:
+        try:
+            start_time = time.perf_counter()
+            async with self.lichess_session.get('/__ping'):
+                return time.perf_counter() - start_time
+        except (aiohttp.ClientError, TimeoutError):
+            return float('NaN')
 
     @retry(**BASIC_RETRY_CONDITIONS)
     async def resign_game(self, game_id: str) -> bool:

--- a/chatter.py
+++ b/chatter.py
@@ -1,6 +1,7 @@
 import os
 import platform
 from collections import defaultdict
+import ping3  
 
 import psutil
 
@@ -81,6 +82,15 @@ class Chatter:
                                                                         'Feel free to challenge me again, '
                                                                         'I will accept the challenge if possible.'))
 
+    def _get_ping(self) -> str:
+        try:
+            ping_ms = ping3.ping("lichess.org", unit="ms", timeout=2)
+            if ping_ms is None:
+                return "Ping to lichess.org failed."
+            return f"Ping to lichess.org: {ping_ms:.0f} ms"
+        except Exception as e:
+            return f"Ping error: {e}"
+
     async def _handle_command(self, chat_message: Chat_Message, takeback_count: int, max_takebacks: int) -> None:
         match chat_message.text[1:].lower():
             case 'cpu':
@@ -120,12 +130,14 @@ class Chatter:
                 await self.api.send_chat_message(self.game_info.id_, chat_message.room, self.ram_message)
             case 'takeback':
                 await self._send_takeback_message(chat_message.room, takeback_count, max_takebacks)
+            case 'ping':
+                ping_message = self._get_ping()
+                await self.api.send_chat_message(self.game_info.id_, chat_message.room, ping_message)
             case 'help' | 'commands':
                 if chat_message.room == 'player':
-                    message = 'Supported commands: !cpu, !draw, !eval, !motor, !name, !printeval, !ram, !takeback'
+                    message = 'Supported commands: !cpu, !draw, !eval, !motor, !name, !printeval, !ram, !takeback, !ping'
                 else:
-                    message = 'Supported commands: !cpu, !draw, !eval, !motor, !name, !printeval, !pv, !ram, !takeback'
-
+                    message = 'Supported commands: !cpu, !draw, !eval, !motor, !name, !printeval, !pv, !ram, !takeback, !ping'
                 await self.api.send_chat_message(self.game_info.id_, chat_message.room, message)
 
     async def _send_last_message(self, room: str) -> None:
@@ -213,16 +225,4 @@ class Chatter:
         if board.turn:
             initial_message += 'PV:'
         else:
-            initial_message += f'PV: {board.fullmove_number}...'
-
-        final_message = initial_message
-        for move in self.lichess_game.last_pv[1:]:
-            if board.turn:
-                initial_message += f' {board.fullmove_number}.'
-            initial_message += f' {board.san(move)}'
-            if len(initial_message) > 140:
-                break
-            board.push(move)
-            final_message = initial_message
-
-        return final_message
+                initial_message += f'PV: {board.fullmove_number}...'

--- a/chatter.py
+++ b/chatter.py
@@ -1,7 +1,7 @@
 import os
 import platform
 from collections import defaultdict
-import asyncio
+
 import psutil
 
 from api import API
@@ -94,7 +94,11 @@ class Chatter:
             case 'name':
                 await self.api.send_chat_message(self.game_info.id_, chat_message.room, self.name_message)
             case 'ping':
-                await self._handle_ping_command(chat_message)
+                if not self.game_info.increment_ms and self.lichess_game.own_time < 10.0:
+                    return
+
+                ping = await self.api.ping()
+                await self.api.send_chat_message(self.game_info.id_, chat_message.room, f'Ping: {ping:.1f}')
             case 'printeval':
                 if not self.game_info.increment_ms and self.game_info.initial_time_ms < 180_000:
                     await self._send_last_message(chat_message.room)
@@ -124,34 +128,13 @@ class Chatter:
                 await self._send_takeback_message(chat_message.room, takeback_count, max_takebacks)
             case 'help' | 'commands':
                 if chat_message.room == 'player':
-                    message = 'Supported commands: !cpu, !draw, !eval, !motor, !name, !ping, !printeval, !ram, !takeback'
+                    message = ('Supported commands: !cpu, !draw, !eval, !motor, '
+                               '!name, !ping, !printeval, !ram, !takeback')
                 else:
-                    message = 'Supported commands: !cpu, !draw, !eval, !motor, !name, !ping, !printeval, !pv, !ram, !takeback'
+                    message = ('Supported commands: !cpu, !draw, !eval, !motor, '
+                               '!name, !ping, !printeval, !pv, !ram, !takeback')
 
                 await self.api.send_chat_message(self.game_info.id_, chat_message.room, message)
-            case _:
-                pass
-
-    async def _handle_ping_command(self, chat_message: Chat_Message) -> None:
-        ping_ms = await self._get_ping("lichess.org")
-        await self.api.send_chat_message(self.game_info.id_, chat_message.room, f"Ping: {ping_ms}")
-
-    async def _get_ping(self, host: str) -> str:
-        try:
-            count_flag = "-n" if platform.system().lower().startswith("win") else "-c"
-            proc = await asyncio.create_subprocess_exec(
-                "ping", count_flag, "1", host,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE
-            )
-            stdout, _ = await proc.communicate()
-            output = stdout.decode()
-            for line in output.splitlines():
-                if "time=" in line.lower():
-                    return line.split("time=")[1].split()[0]
-            return "unknown"
-        except Exception as e:
-            return f"error: {e}"
 
     async def _send_last_message(self, room: str) -> None:
         last_message = self.lichess_game.last_message.replace('Engine', 'Evaluation')


### PR DESCRIPTION
This update adds a new !ping command to BotLi, allowing users to check the bot's network latency to lichess.org directly from the chat. When a user types !ping, the bot responds with the current ping time in milliseconds or an error message if the ping fails.

Benefits:

Users can quickly assess the bot's connection quality to lichess.org.
Useful for troubleshooting network issues and monitoring bot responsiveness during games.
Technical Details:

Utilizes the [ping3](vscode-file://vscode-app/c:/Users/doqua/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) Python library for direct ICMP ping measurement.
Handles network errors gracefully and provides clear feedback.