### PR TITLE
Add !use command for listing and explaining bot commands

### DIFF
--- a/chatter.py
+++ b/chatter.py
@@ -9,6 +9,22 @@ from botli_dataclasses import Chat_Message, Game_Information
 from config import Config
 from lichess_game import Lichess_Game
 
+COMMANDS = {
+    'cpu': 'Shows information about the bot\'s CPU (processor, cores, threads, frequency).',
+    'draw': 'Explains the bot\'s draw offering/accepting policy based on evaluation and game length.',
+    'eval': 'Shows the latest position evaluation.',
+    'motor': 'Displays the name of the chess motor currently being used.',
+    'name': 'Shows the bot\'s name and motor information.',
+    'ping': 'Tests the network connection latency to Lichess servers.',
+    'printeval': 'Enables automatic printing of evaluations after each move (use !quiet to stop).',
+    'quiet': 'Stops automatic evaluation printing (use after !printeval).',
+    'ram': 'Displays the amount of system memory (RAM).',
+    'takeback': 'Shows how many takebacks are allowed and how many the opponent has used.'
+}
+SPECTATOR_COMMANDS = {
+    'pv': 'Shows the principal variation (best line of play) from the latest position.'
+}
+
 
 class Chatter:
     def __init__(self,
@@ -126,20 +142,21 @@ class Chatter:
                 await self.api.send_chat_message(self.game_info.id_, chat_message.room, self.ram_message)
             case 'takeback':
                 await self._send_takeback_message(chat_message.room, takeback_count, max_takebacks)
-            case 'help' | 'commands':
-                if arg:
-                    command = arg.lstrip("!")
-                    explanation = self._get_command_explanation(f"!{command.lower()}", chat_message.room)
-                    await self.api.send_chat_message(self.game_info.id_, chat_message.room, explanation)
-                else:
-                    if chat_message.room == 'player':
-                        message = ('Supported commands: !cpu, !draw, !eval, !motor, !name, !ping, !printeval, !ram, !takeback. '
-                                   'Type !help <command> for more information.')
-                    else:
-                        message = ('Supported commands: !cpu, !draw, !eval, !motor, !name, !ping, !printeval, !pv, !ram, !takeback. '
-                                   'Type !help <command> for more information.')
+            case command if command.startswith('help'):
+                commands = COMMANDS if chat_message.room == 'player' else COMMANDS | SPECTATOR_COMMANDS
+                words = chat_message.text.split()
+                if len(words) == 1:
+                    message = f'Commands: !{", !".join(commands)}. Type !help <command> for more information.'
                     await self.api.send_chat_message(self.game_info.id_, chat_message.room, message)
+                    return
 
+                command = words[1].lstrip('!').lower()
+                if command in commands:
+                    message = f'!{command}: {commands[command]}'
+                else:
+                    message = f'Unknown command: "!{command}". Type !help for a list of available commands.'
+
+                await self.api.send_chat_message(self.game_info.id_, chat_message.room, message)
 
     async def _send_last_message(self, room: str) -> None:
         last_message = self.lichess_game.last_message.replace('Engine', 'Evaluation')
@@ -244,26 +261,3 @@ class Chatter:
             final_message = initial_message
 
         return final_message
-
-    def _get_command_explanation(self, command: str, room: str) -> str:
-        explanations = {
-            '!help': 'Shows all available commands which you can use.',
-            '!cpu': 'Shows information about the bot\'s CPU (processor, cores, threads, frequency).',
-            '!draw': 'Explains the bot\'s draw offering/accepting policy based on evaluation and game length.',
-            '!eval': 'Shows the current position evaluation from the chess engine.',
-            '!motor': 'Displays the name of the chess engine currently being used.',
-            '!name': 'Shows the bot\'s name and engine information.',
-            '!printeval': 'Enables automatic printing of evaluations after each move (use !quiet to stop).',
-            '!pv': 'Shows the principal variation (best line of play) from the current position.' if room != 'player' else None,
-            '!ram': 'Displays the amount of system memory (RAM) available to the bot.',
-            '!ping': 'Tests the network connection latency to Lichess servers.',
-            '!takeback': 'Shows how many takebacks are allowed and how many the opponent has used.',
-            '!quiet': 'Stops automatic evaluation printing (use after !printeval).',
-        }
-
-        if command in explanations and explanations[command] is not None:
-            return f'{command}: {explanations[command]}'
-        elif command == '!pv' and room == 'player':
-            return '!pv: This command is only available in spectator chat.'
-        else:
-            return f'Unknown command: {command}. Type !help to see all available commands.'

--- a/chatter.py
+++ b/chatter.py
@@ -32,6 +32,7 @@ class Chatter:
         self.spectator_greeting = self._format_message(config.messages.greeting_spectators)
         self.spectator_goodbye = self._format_message(config.messages.goodbye_spectators)
         self.print_eval_rooms: set[str] = set()
+        self.pending_use_requests: dict[str, str] = {}
 
     async def handle_chat_message(self, chatLine_Event: dict, takeback_count: int, max_takebacks: int) -> None:
         chat_message = Chat_Message.from_chatLine_event(chatLine_Event)
@@ -129,10 +130,10 @@ class Chatter:
             case 'help' | 'commands':
                 if chat_message.room == 'player':
                     message = ('Supported commands: !cpu, !draw, !eval, !motor, '
-                               '!name, !ping, !printeval, !ram, !takeback')
+                               '!name, !ping, !printeval, !ram, !takeback, !use')
                 else:
                     message = ('Supported commands: !cpu, !draw, !eval, !motor, '
-                               '!name, !ping, !printeval, !pv, !ram, !takeback')
+                               '!name, !ping, !printeval, !pv, !ram, !takeback, !use')
 
                 await self.api.send_chat_message(self.game_info.id_, chat_message.room, message)
 
@@ -239,3 +240,60 @@ class Chatter:
             final_message = initial_message
 
         return final_message
+
+    async def _handle_use_command(self, chat_message: Chat_Message) -> None:
+        user_room_key = f"{chat_message.username}_{chat_message.room}"
+        
+        parts = chat_message.text.strip().split(maxsplit=1)
+        if len(parts) > 1:
+            cmd = parts[1].strip().lstrip("!")
+            command = f'!{cmd.lower()}'
+            explanation = self._get_command_explanation(command, chat_message.room)
+            await self.api.send_chat_message(self.game_info.id_, chat_message.room, explanation)
+            return
+
+        self.pending_use_requests[user_room_key] = chat_message.room
+
+        if chat_message.room == 'player':
+            commands_list = 'cpu, draw, eval, motor, name, printeval, ram, ping, roast, destroy, quotes'
+        else:
+            commands_list = 'cpu, draw, eval, motor, name, printeval, pv, ram, ping, roast, destroy, quotes'
+
+        await self.api.send_chat_message(self.game_info.id_, chat_message.room, f"Available commands: {commands_list}.")
+        await self.api.send_chat_message(self.game_info.id_, chat_message.room, "Which command would you like me to explain?")
+
+
+    async def _handle_use_explanation(self, chat_message: Chat_Message) -> None:
+        user_room_key = f"{chat_message.username}_{chat_message.room}"
+        room = self.pending_use_requests.pop(user_room_key, None)
+        if not room:
+            return
+
+        cmd = chat_message.text.strip().lstrip("!")
+        command = f'!{cmd.lower()}'
+
+        explanation = self._get_command_explanation(command, room)
+        await self.api.send_chat_message(self.game_info.id_, room, explanation)
+
+    def _get_command_explanation(self, command: str, room: str) -> str:
+        explanations = {
+            '!help': 'Shows all available commands which you can use.',
+            '!cpu': 'Shows information about the bot\'s CPU (processor, cores, threads, frequency).',
+            '!draw': 'Explains the bot\'s draw offering/accepting policy based on evaluation and game length.',
+            '!eval': 'Shows the current position evaluation from the chess engine.',
+            '!motor': 'Displays the name of the chess engine currently being used.',
+            '!name': 'Shows the bot\'s name and engine information.',
+            '!printeval': 'Enables automatic printing of evaluations after each move (use !quiet to stop).',
+            '!pv': 'Shows the principal variation (best line of play) from the current position.' if room != 'player' else None,
+            '!ram': 'Displays the amount of system memory (RAM) available to the bot.',
+            '!ping': 'Tests the network connection latency to Lichess servers.',
+            '!quiet': 'Stops automatic evaluation printing (use after !printeval).',
+            '!use': 'Tells the use of any command.'
+        }
+
+        if command in explanations and explanations[command] is not None:
+            return f'{command}: {explanations[command]}'
+        elif command == '!pv' and room == 'player':
+            return '!pv: This command is only available in spectator chat.'
+        else:
+            return f'Unknown command: {command}. Type !help to see all available commands.'


### PR DESCRIPTION
**This PR introduces a new `!use` command that improves the discoverability and clarity of available bot commands, while making the bot more helpful and kind.**

---

### **What’s new**

- `!use` (without arguments) **lists all available commands.**  
- After listing, you can type either `!<command>` or `<command>` (e.g., `!eval` or `eval`) to get an explanation.  
- You can also type `!use <command>` or `!use !<command>` directly to receive the explanation in one step.  
- Added `!use` to the `!help` output so users know about this feature.  

---

### **Why this is useful**

**Torom, yes, I agree with you that many people already know the commands and they may seem self-explanatory. However, not everyone is familiar with them—especially new or casual players who may not understand technical terms right away.**

- `eval`, `pv`, and `printeval` are **not obvious** to someone who doesn’t follow engine terminology.  
- `cpu` and `ram` can look like confusing technical jargon.  
- New players often hesitate to ask questions in chat, but they will happily type a command if prompted.  

By explaining commands clearly, the bot comes across as **friendly, helpful, and kind** rather than assuming users already know everything.

---

### **Benefits**

- Makes the bot **more accessible to beginners.**  
- Reduces confusion for casual players.  
- Encourages exploration of features at a user’s own pace.  
- Shows that the bot is **welcoming and supportive.**

This way, the bot is not just strong—_it’s approachable and kind, too._  

---

**Thank you.**
<img width="820" height="1113" alt="image_2025-09-14_092846904" src="https://github.com/user-attachments/assets/cc2f8fe0-f6cf-4c9b-8059-e550765b601f" />
