### PR TITLE
Fix opening books validation when opening_books is disabled in config.yml

### DIFF
--- a/config.py
+++ b/config.py
@@ -221,6 +221,8 @@ class Config:
 
     @staticmethod
     def _get_opening_books_config(config: dict[str, Any]) -> Opening_Books_Config:
+        if not config.get("opening_books", {}).get("enabled", False):
+            return Opening_Books_Config(False, 0, None, {})
         opening_books_sections: list[tuple[str, type | UnionType, str]] = [
             ("enabled", bool, '"enabled" must be a bool.'),
             ("priority", int, '"priority" must be an integer.'),
@@ -239,13 +241,11 @@ class Config:
             Config._validate_config_section(settings, f"opening_books.{section}", opening_book_types_sections)
 
             names: dict[str, str] = {}
-            for book_name in settings["names"]:
-                if book_name not in config["books"]:
+            for book_name in settings.get("names", []):
+                if book_name not in config.get("books", {}):
                     raise RuntimeError(f'The book "{book_name}" is not defined in the books section.')
-
                 if not os.path.isfile(config["books"][book_name]):
                     raise RuntimeError(f'The book "{book_name}" at "{config["books"][book_name]}" does not exist.')
-
                 names[book_name] = config["books"][book_name]
 
             books[section] = Books_Config(

--- a/config.py
+++ b/config.py
@@ -221,8 +221,6 @@ class Config:
 
     @staticmethod
     def _get_opening_books_config(config: dict[str, Any]) -> Opening_Books_Config:
-        if not config.get("opening_books", {}).get("enabled", False):
-            return Opening_Books_Config(False, 0, None, {})
         opening_books_sections: list[tuple[str, type | UnionType, str]] = [
             ("enabled", bool, '"enabled" must be a bool.'),
             ("priority", int, '"priority" must be an integer.'),
@@ -230,6 +228,9 @@ class Config:
         ]
 
         Config._validate_config_section(config["opening_books"], "opening_books", opening_books_sections)
+
+        if not config["opening_books"]["enabled"]:
+            return Opening_Books_Config(False, 0, None, {})
 
         opening_book_types_sections: list[tuple[str, type | UnionType, str]] = [
             ("selection", str, '"selection" must be one of "weighted_random", "uniform_random" or "best_move".'),
@@ -241,11 +242,13 @@ class Config:
             Config._validate_config_section(settings, f"opening_books.{section}", opening_book_types_sections)
 
             names: dict[str, str] = {}
-            for book_name in settings.get("names", []):
-                if book_name not in config.get("books", {}):
+            for book_name in settings["names"]:
+                if book_name not in config["books"]:
                     raise RuntimeError(f'The book "{book_name}" is not defined in the books section.')
+
                 if not os.path.isfile(config["books"][book_name]):
                     raise RuntimeError(f'The book "{book_name}" at "{config["books"][book_name]}" does not exist.')
+
                 names[book_name] = config["books"][book_name]
 
             books[section] = Books_Config(


### PR DESCRIPTION
**In some recent commit to BotLi there seems to have been added a way to check whether the Book to the path exists. Now if I have no Book anywhere which I could give there I am unable to start the Bot.**

**It wants at least 1 valid Book. But I don't have one in that case and don't want one. There should be a way to handle that without giving the config a book**

**_A person had this error, this commit fixes it._**

**Summary:**
**This PR updates _get_opening_books_config to skip all book-related validation when opening_books.enabled is set to false in config.yml. Previously, the method would attempt to validate paths, book names, and files even if the opening books were disabled, potentially causing errors.**

**_I hope this is enough to explain the error and fix. Thanks!_**